### PR TITLE
Remove unneeded configuration file

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,3 +1,0 @@
-load 'deploy' if respond_to?(:namespace) # cap2 differentiator
-Dir['vendor/plugins/*/recipes/*.rb'].each { |plugin| load(plugin) }
-load 'config/deploy'


### PR DESCRIPTION
Since capistrano is not part of the Gemfile and no further configuration is provided in the repositiory, the Capfile is not needed anymore.