### PR TITLE
added sticky stacked nav

### DIFF
--- a/app/assets/javascripts/worktimes.js.coffee
+++ b/app/assets/javascripts/worktimes.js.coffee
@@ -10,6 +10,7 @@ app.worktimes = new class
   scrollSpeed = 300
   activationEnabled = true
   worktimesWaypoint = null
+  headerOffset = 0
 
   toggle = (selector, disable) ->
     $(selector).prop('disabled', disable)
@@ -82,6 +83,8 @@ app.worktimes = new class
       worktimesWaypoint.destroy()
       worktimesWaypoint = null
 
+    headerOffset = (if $(window).width() > 768 then $('header').height() else 0) #set offset of header
+
     if @container().length
       @container('.weekcontent .date-label')
         .waypoint(
@@ -91,7 +94,7 @@ app.worktimes = new class
             else if direction == 'up' && $(this.element).prev().length
               app.worktimes.activateNavDayWithDate($(this.element).prev().data('date'))
           ,
-          offset: -> $('.weeknav').height()
+          offset: -> $('.weeknav').height() + headerOffset
         )
 
       @container('.weeknav .day').on('click', (e) =>
@@ -137,7 +140,7 @@ app.worktimes = new class
     if dateLabel.length is 0
       return
 
-    offset = dateLabel.offset().top - @container('.weeknav').height() - 20
+    offset = dateLabel.offset().top - @container('.weeknav').height() - 20 - headerOffset
     @scrollTo(offset, @activateNavDayWithDate, date)
 
   scrollTo: (offset, callback, date) ->

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -3,6 +3,13 @@
 //  or later. See the COPYING file at the top-level directory or at
 //  https://github.com/puzzle/puzzletime.
 
+@media (min-width: 768px) {
+  header {
+    position: sticky;
+    z-index: 3; // because some inputs are also z-index 2
+    top: 0;
+  }
+}
 
 .navbar {
   z-index: 2;

--- a/app/assets/stylesheets/_worktimes.scss
+++ b/app/assets/stylesheets/_worktimes.scss
@@ -387,6 +387,10 @@ $worktimes-weekcontent-hover-bg: $gray-lighter;
   z-index: 2;
   padding: $padding-base-vertical 0;
 
+  @media (min-width: 768px) {
+    top: 134px;
+  }
+
   &.stuck {
     position: fixed;
     width: 100%;


### PR DESCRIPTION
Could be a solution for issue #29 

added sticky on nav with z-index 3 because of some input fields with z-index 2.

sticky is only set on desktop not mobile, because the nav is too big 

GIF:
![stickyNav](https://user-images.githubusercontent.com/17859972/55988116-4f37ea80-5ca3-11e9-96af-8359955fc681.gif)

