### PR TITLE
Fix musthour line in week graph

### DIFF
--- a/app/domain/graphs/timebox.rb
+++ b/app/domain/graphs/timebox.rb
@@ -25,7 +25,9 @@ class Timebox
     end
 
     def height_from_hours(hours)
-      hours * PIXEL_PER_HOUR
+      # Round to fix pixel display issues
+      rounded = (hours * 4).round / 4.0
+      rounded * PIXEL_PER_HOUR
     end
 
     def format_hour(hour)


### PR DESCRIPTION
The calculations were correct, but translated to non-displayable pixel values.
e.g. 10.1px / 12.9px. By rounding the time to the next quarter hour it solves
this.