### PR TITLE
Feature/48928/add json api pagination control

### DIFF
--- a/app/controllers/api/jsonapi_controller.rb
+++ b/app/controllers/api/jsonapi_controller.rb
@@ -16,6 +16,8 @@ module Api
   class JsonapiController < ManageController
     include Apidocs::Annotations::Controller
 
+    before_action :set_pagination_headers, only: :index
+
     class IncludeError < StandardError
       def self.===(exception)
         exception.class == ArgumentError &&
@@ -78,8 +80,25 @@ module Api
 
     private
 
+    def set_pagination_headers
+      response.headers.merge!(
+        'PaginationTotalCount' => list_entries.total_count,
+        'PagionationPerPage' => list_entries.current_per_page,
+        'PaginationCurrentPage' => list_entries.current_page,
+        'PaginationTotalPages' => list_entries.total_pages
+      )
+    end
+
+    def list_entries
+      super.per(page_params[:per_page])
+    end
+
     def include_param
       params.permit(:include)[:include].try(:split, ',')
+    end
+
+    def page_params
+      params.permit(:page, :per_page)
     end
   end
 end

--- a/doc/user/api.md
+++ b/doc/user/api.md
@@ -10,6 +10,24 @@ Alle implementierten Endpunkte sind mit [HTTP Basic Authentication][basic_auth] 
 Die Credentials sind in der aktuellen Implementierung global definiert und werden von allen API clients geteilt.
 Sie müssen auf dem Server über Umgebungsvariablen konfiguriert werden (siehe [/doc/development/03_deployment.md])
 
+## Pagination
+
+Die Pagination wird mithilfe von Kaminari über DryCrud realisisert.
+Somit unterstützt die API folgende Query Parameter:
+
+|Parameter|Beispiel|Funktion|
+| ------- | ------ | ------ |
+| ```page``` | ```/api/v1/employees?page=2``` | Wählt die gewünschte Seite aus |
+| ```per_page``` | ```/api/v1/employees?per_page=100``` | Wählt die gewünschte Anzahl Resultate aus |
+
+Zusätzlich gibt es folgende Header um sich zu orientieren:
+
+| Header | Beispielwert | Funktion |
+| ------ | ------------ | -------- |
+| PaginationTotalCount | 186 | Enthält die Gesamte Anzahl der gewünschten Resource |
+| PagionationPerPage | 10 | Enthält die zurückgegebene Anzahl von Elementen |
+| PaginationCurrentPage | 2 | Enthält die zurückgegebene Seite |
+| PaginationTotalPages | 19 | Enthält die gesamte Anzahl der Seiten |
 
 
 ## API Dokumentation

--- a/test/controllers/api/v1/employees_controller_test.rb
+++ b/test/controllers/api/v1/employees_controller_test.rb
@@ -44,6 +44,30 @@ class Api::V1::EmployeesControllerTest < ActionController::TestCase
     assert_equal Employee.current.count, response_json[:data].count
   end
 
+  (1..3).each do |i|
+    test "pagination per_page works with #{i}" do
+      get :index, params: { per_page: i }
+      assert_equal i, response_json[:data].count
+    end
+
+    test "pagination page works with #{i}" do
+      get :index, params: { page: i }
+      expected = Employee.list.page(i).pluck(:id)
+      actual   = response_json[:data].map { |d| d[:id].to_i }
+      assert_equal expected, actual
+    end
+  end
+
+  test "pagination headers are present" do
+    get :index, params: { page: 2, per_page: 1 }
+    list_entries = Employee.list.page(2).per(1)
+
+    assert_equal list_entries.total_count,      response.headers['PaginationTotalCount']
+    assert_equal list_entries.current_per_page, response.headers['PagionationPerPage']
+    assert_equal list_entries.current_page,     response.headers['PaginationCurrentPage']
+    assert_equal list_entries.total_pages,      response.headers['PaginationTotalPages']
+  end
+
   private
 
   def basic_auth_header


### PR DESCRIPTION
Die Kaminari Pagination wird von DryCrud geerbt und zeigt somit Standardmässig 20 Resultate an (0-19). Es unterstützt zwar den page parameter, aber dies ist nirgends dokumentiert. Momentan müsste man die pages durchgehen bis ein leeres Array zurückkommt.

Jetzt kann man mit `per_pages` die Anzahl der Elemente steuern und in den Headern hat es Pagination relevante Informationen.

Die Dokumentation wurde um diese Informationen ergänzt.