### PR TITLE
Fix airbreak config for test and development

### DIFF
--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -5,34 +5,31 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/puzzle/puzzletime.
 
+Airbrake.configure do |config|
+  config.environment = Rails.env
+  config.ignore_environments = [:development, :test]
+  # if no host is given, ignore all environments
+  config.ignore_environments << :production if ENV['RAILS_AIRBRAKE_HOST'].blank?
 
-if ENV['RAILS_AIRBRAKE_HOST'] && ENV['RAILS_AIRBRAKE_API_KEY']
-  Airbrake.configure do |config|
-    config.environment = Rails.env
-    config.ignore_environments = [:development, :test]
-    # if no host is given, ignore all environments
-    config.ignore_environments << :production if ENV['RAILS_AIRBRAKE_HOST'].blank?
+  config.project_id     = 1 # required, but any positive integer works
+  config.project_key    = ENV['RAILS_AIRBRAKE_API_KEY']
+  config.host           = ENV['RAILS_AIRBRAKE_HOST']
+  config.blacklist_keys << 'pwd'
+  config.blacklist_keys << 'RAILS_DB_PASSWORD'
+  config.blacklist_keys << 'RAILS_AIRBRAKE_API_KEY'
+  config.blacklist_keys << 'RAILS_SECRET_TOKEN'
+  config.blacklist_keys << 'RAILS_SECRET_KEY_BASE'
+  config.blacklist_keys << 'RAILS_HIGHRISE_TOKEN'
+  config.blacklist_keys << 'RAILS_SMALL_INVOICE_TOKEN'
+end
 
-    config.project_id     = 1 # required, but any positive integer works
-    config.project_key    = ENV['RAILS_AIRBRAKE_API_KEY']
-    config.host           = ENV['RAILS_AIRBRAKE_HOST']
-    config.blacklist_keys << 'pwd'
-    config.blacklist_keys << 'RAILS_DB_PASSWORD'
-    config.blacklist_keys << 'RAILS_AIRBRAKE_API_KEY'
-    config.blacklist_keys << 'RAILS_SECRET_TOKEN'
-    config.blacklist_keys << 'RAILS_SECRET_KEY_BASE'
-    config.blacklist_keys << 'RAILS_HIGHRISE_TOKEN'
-    config.blacklist_keys << 'RAILS_SMALL_INVOICE_TOKEN'
-  end
+ignored_exceptions = %w(ActionController::MethodNotAllowed
+                        ActionController::RoutingError
+                        ActionController::InvalidAuthenticityToken
+                        ActionController::UnknownHttpMethod)
 
-  ignored_exceptions = %w(ActionController::MethodNotAllowed
-                          ActionController::RoutingError
-                          ActionController::InvalidAuthenticityToken
-                          ActionController::UnknownHttpMethod)
-
-  Airbrake.add_filter do |notice|
-    if (notice[:errors].map { |e| e[:type] } & ignored_exceptions).present?
-      notice.ignore!
-    end
+Airbrake.add_filter do |notice|
+  if (notice[:errors].map { |e| e[:type] } & ignored_exceptions).present?
+    notice.ignore!
   end
 end


### PR DESCRIPTION
The conditional causes an error in development if the env variables are
not set, because airbreak is then not configured at all.

It is no longer required to provide the host and key.

For reference: https://github.com/airbrake/airbrake/issues/713