### PR TITLE
Fix total sum calculation in employee eval

### DIFF
--- a/app/domain/evaluations/employees_eval.rb
+++ b/app/domain/evaluations/employees_eval.rb
@@ -34,6 +34,16 @@ class EmployeesEval < Evaluation
     division.id if division
   end
 
+  def sum_total_times(period = nil)
+    query = if @department_id != 0
+              Department.find(@department_id).employee_worktimes
+            else
+              Worktime.all
+            end
+    query = query.where(type: worktime_type).in_period(period)
+    query_time_sums(query)
+  end
+
   def division_supplement(_user)
     [[:overtime, 'Überstunden', 'right'],
      [:overtime_vacations_tooltip, '', 'left'],

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -18,6 +18,7 @@ class Department < ActiveRecord::Base
 
   has_many :orders
   has_many :employees, dependent: :nullify
+  has_many :employee_worktimes, through: :employees, source: :worktimes
 
   validates_by_schema
 

--- a/test/domain/evaluations/employees_eval_test.rb
+++ b/test/domain/evaluations/employees_eval_test.rb
@@ -38,6 +38,12 @@ class EmployeesEvalTest < ActiveSupport::TestCase
     assert_sum_total_times 3.0, 30.0, 53.0, 54.0
   end
 
+  def test_employees_by_department
+    @evaluation = EmployeesEval.new(departments(:devtwo).id)
+
+    assert_sum_total_times 3.0, 12.0, 35.0, 36.0
+  end
+
   def test_employee_detail_mark
     @evaluation.set_division_id employees(:mark).id
 
@@ -58,6 +64,4 @@ class EmployeesEvalTest < ActiveSupport::TestCase
     assert_sum_times 3, 3, 5, 6
     assert_count_times 1, 1, 2, 3
   end
-
-
 end


### PR DESCRIPTION
This fixes the sum of all work times when a depatment is selected. Previously this always returned the sum of all depatments.