### PR TITLE
Make meal compensation optional

### DIFF
--- a/app/views/accounting_posts/_form.html.haml
+++ b/app/views/accounting_posts/_form.html.haml
@@ -33,7 +33,8 @@
   = f.labeled_input_field :portfolio_item_id, span: 5
   = f.labeled_input_field :service_id, span: 5
   = f.labeled_input_field :billable, caption: 'Budgetposition ist verrechenbar'
-  = f.labeled_input_field :meal_compensation, caption: 'Member hat Anrecht auf Verpflegungsentschädigung'
+  - if Settings.meal_compensation.present?
+    = f.labeled_input_field :meal_compensation, caption: 'Member hat Anrecht auf Verpflegungsentschädigung'
 
   = f.labeled_input_field :description_required, caption: 'Beschreibung obligatorisch', disabled: desc
   = f.labeled_input_field :ticket_required, caption: 'Ticket obligatorisch', disabled: tick

--- a/app/views/layouts/_menu.html.haml
+++ b/app/views/layouts/_menu.html.haml
@@ -51,7 +51,7 @@
             reports_workload_path,
             reports_role_distribution_path,
             vacations_path,
-            meal_compensations_path
+            Settings.meal_compensation.present? ? meal_compensations_path : nil
 
 
       - if can?(:manage, Client)

--- a/app/views/order_services/_value_filters.html.haml
+++ b/app/views/order_services/_value_filters.html.haml
@@ -8,5 +8,6 @@
 = direct_filter_select(:work_item_id, 'Buchungsposition', @accounting_posts)
 = direct_filter_select(:ticket, 'Ticket', @tickets, value_method: :to_s)
 = direct_filter_select(:billable, 'Verrechenbar', yes_no_options)
-= direct_filter_select(:meal_compensation, 'Verpflegungs-Entschädigung', yes_no_options)
+- if Settings.meal_compensation.present?
+  = direct_filter_select(:meal_compensation, 'Verpflegungs-Entschädigung', yes_no_options)
 = direct_filter_select(:invoice_id, 'Rechnungsnr.', @invoices, text_method: :reference)

--- a/app/views/ordertimes/_form.html.haml
+++ b/app/views/ordertimes/_form.html.haml
@@ -43,7 +43,8 @@
       = f.text_field(:to_end_time, value: format_time(@worktime.to_end_time))
 
   = f.labeled_boolean_field(:billable, detail: 'Leistung ist verrechenbar.')
-  = f.labeled_boolean_field(:meal_compensation, detail: "Ich war vor Ort beim Kunden und habe Anrecht auf die #{link_to('Verpflegungsentschädigung', Settings.meal_compensation.url)}.".html_safe)
+  - if Settings.meal_compensation.present?
+    = f.labeled_boolean_field(:meal_compensation, detail: "Ich war vor Ort beim Kunden und habe Anrecht auf die #{link_to('Verpflegungsentschädigung', Settings.meal_compensation.url)}.".html_safe)
 
   .form-group
     .col-md-offset-2.col-md-8

--- a/app/views/shared/_submenu_employees.html.haml
+++ b/app/views/shared/_submenu_employees.html.haml
@@ -31,5 +31,6 @@
   = nav 'Funktionsanteile',
         reports_role_distribution_path
 
-- if can?(:meal_compensation, Evaluation)
-  = nav 'Verpflegungs-Entschädigungen', meal_compensations_path
+- if Settings.meal_compensation.present?
+  - if can?(:meal_compensation, Evaluation)
+    = nav 'Verpflegungs-Entschädigungen', meal_compensations_path

--- a/app/views/worktimes/_worktime.html.haml
+++ b/app/views/worktimes/_worktime.html.haml
@@ -7,8 +7,9 @@
 .entry{'data-date' => day}
   - unless worktime.billable
     %i.billable-icon.icon-dollar-stroke
-  - if worktime.meal_compensation
-    %i.meal-compensation-icon.icon-fork-and-knife
+  - if Settings.meal_compensation.present?
+    - if worktime.meal_compensation
+      %i.meal-compensation-icon.icon-fork-and-knife
   .title-description
     .title= worktime_account(worktime)
     .description= worktime_description(worktime)


### PR DESCRIPTION
Make meal compensation optional depending on if the key 'meal_compensation' is existing in the settings.yam similar to other features.