### PR TITLE
Revert "Add time_zone to config"

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -44,7 +44,7 @@ module Puzzletime
     # Attention: Setting a time zone here will confuse OpenShift.
     # We leave the Time zone on UTC as recommended by
     # https://robots.thoughtbot.com/its-about-time-zones
-    config.time_zone = 'Bern'
+    # config.time_zone = 'Bern'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/test/helpers/format_helper_test.rb
+++ b/test/helpers/format_helper_test.rb
@@ -156,7 +156,7 @@ class FormatHelperTest < ActionView::TestCase
 
   test 'format time column' do
     m = crud_test_models(:AAAAA)
-    assert_equal '02:01', format_type(m, :gets_up_at)
+    assert_equal '01:01', format_type(m, :gets_up_at)
   end
 
   test 'format text column' do


### PR DESCRIPTION
This reverts commit f410a8a9135170241fbd3d39fded4907e9c9c5aa.
New times are recorded and displayed correctly, but old times are +1
hour.