### PR TITLE
Use cuprite as capybara driver

### DIFF
--- a/.github/workflows/rails-tests.yaml
+++ b/.github/workflows/rails-tests.yaml
@@ -18,6 +18,8 @@ jobs:
   build:
     runs-on: 'ubuntu-latest'
 
+    timeout-minutes: 15
+
     strategy:
       matrix:
         ruby: [ '2.6', '2.7' ]

--- a/.github/workflows/rails-tests.yaml
+++ b/.github/workflows/rails-tests.yaml
@@ -55,6 +55,8 @@ jobs:
         RAILS_TEST_DB_USERNAME: 'postgres'
         RAILS_TEST_DB_PASSWORD: 'postgres'
         RAILS_ENV: 'test'
+        CI: 'true'
+        PGDATESTYLE: German
       run: |
         sudo apt-get -yqq install libpq-dev
         gem install bundler --version '~> 2'

--- a/Gemfile
+++ b/Gemfile
@@ -86,14 +86,11 @@ end
 
 group :test do
   gem 'bundler-audit'
-  gem 'capybara'
+  gem 'cuprite'
   gem 'database_cleaner'
   gem 'fabrication'
-  gem 'headless'
   gem 'mocha', require: false
   gem 'rails-controller-testing'
-  gem 'selenium-webdriver'
-  gem 'webdrivers'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,9 +133,9 @@ GEM
       xpath (~> 3.2)
     chartjs-ror (3.6.4)
       rails (>= 3.1)
-    childprocess (3.0.0)
     choice (0.2.0)
     chunky_png (1.4.0)
+    cliver (0.3.2)
     coderay (1.1.3)
     codez-tarantula (0.5.5)
       hpricot (~> 0.8.4)
@@ -160,6 +160,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    cuprite (0.13)
+      capybara (>= 2.1, < 4)
+      ferrum (~> 0.11.0)
     daemons (1.4.0)
     dalli (2.7.11)
     database_cleaner (2.0.1)
@@ -244,6 +247,11 @@ GEM
     faraday-patron (1.0.0)
     fast_jsonapi (1.5)
       activesupport (>= 4.2)
+    ferrum (0.11)
+      addressable (~> 2.5)
+      cliver (~> 0.3)
+      concurrent-ruby (~> 1.1)
+      websocket-driver (>= 0.6, < 0.8)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -260,7 +268,6 @@ GEM
       sysexits (~> 1.1)
     hashdiff (1.0.1)
     hashie (4.1.0)
-    headless (2.3.1)
     highrise (3.2.3)
       activeresource (>= 3.2.13)
     hpricot (0.8.6)
@@ -480,7 +487,6 @@ GEM
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     ruby2_keywords (0.0.4)
-    rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -497,9 +503,6 @@ GEM
       activerecord (>= 3.1)
       activesupport (>= 3.1)
     selectize-rails (0.12.6)
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
     simplecov (0.21.2)
@@ -553,10 +556,6 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webdrivers (4.6.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.13.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -588,12 +587,12 @@ DEPENDENCIES
   bullet
   bundler-audit
   cancancan
-  capybara
   chartjs-ror
   codez-tarantula
   coffee-rails
   config
   country_select
+  cuprite
   daemons
   dalli
   database_cleaner
@@ -607,7 +606,6 @@ DEPENDENCIES
   fast_jsonapi
   haml
   haml-lint
-  headless
   highrise
   image_processing
   jbuilder
@@ -653,7 +651,6 @@ DEPENDENCIES
   sdoc
   seed-fu
   selectize-rails
-  selenium-webdriver
   sentry-raven
   simplecov-rcov!
   spring
@@ -663,8 +660,7 @@ DEPENDENCIES
   validates_by_schema
   validates_timeliness
   web-console
-  webdrivers
   webmock
 
 BUNDLED WITH
-   2.3.9
+   2.3.12

--- a/test/integration/choose_order_test.rb
+++ b/test/integration/choose_order_test.rb
@@ -31,10 +31,13 @@ class ChooseOrderTest < ActionDispatch::IntegrationTest
   test 'keeps current tab when changing orders' do
     timeout_safe do
       click_link 'Positionen'
-      assert page.has_selector?('a', text: 'Buchungsposition hinzufügen') # dummy query to wait for page load
+
+      assert page.has_link?(href: new_order_accounting_post_path(order_id: order.id)) # query forces to wait for page load
       assert_equal order_accounting_posts_path(order), current_path
 
       selectize('choosable_order_id', 'Demo', term: 'demo', clear: true)
+
+      assert page.has_link?(href: new_order_accounting_post_path(order_id: orders(:hitobito_demo).id)) # query forces to wait for page load
       assert_equal order_accounting_posts_path(orders(:hitobito_demo)), current_path
       assert page.has_selector?('li.active', text: 'Positionen')
     end

--- a/test/integration/create_order_test.rb
+++ b/test/integration/create_order_test.rb
@@ -148,12 +148,16 @@ class CreateOrderTest < ActionDispatch::IntegrationTest
       selectize('client_work_item_id', 'Puzzle')
       check('category_active')
       click_link('category_work_item_id_create_link')
-      click_link('Abbrechen')
+      within('.modal-dialog') do
+        click_link('Abbrechen')
+      end
       selectize('client_work_item_id', 'Swisstopo')
       click_link('category_work_item_id_create_link')
-      fill_in('work_item_name', with: 'New Category')
-      fill_in('work_item_shortname', with: 'NECA')
-      click_button 'Speichern'
+      within('.modal-dialog') do
+        fill_in('work_item_name', with: 'New Category')
+        fill_in('work_item_shortname', with: 'NECA')
+        click_button 'Speichern'
+      end
 
       assert find('#category_work_item_id + .selectize-control').
         has_selector?('.selectize-input .item', text: 'New Category')
@@ -242,9 +246,11 @@ class CreateOrderTest < ActionDispatch::IntegrationTest
       fill_in('order_crm_key', with: '123')
       click_link('Übernehmen')
 
-      assert_equal 'New Client', find('#client_work_item_attributes_name')['value']
-      fill_in('client_work_item_attributes_shortname', with: 'NECL')
-      click_button 'Speichern'
+      within('.modal-dialog') do
+        assert_equal 'New Client', find('#client_work_item_attributes_name')['value']
+        fill_in('client_work_item_attributes_shortname', with: 'NECL')
+        click_button 'Speichern'
+      end
 
       assert_equal 'New Order', find('#order_work_item_attributes_name')['value']
 
@@ -280,8 +286,10 @@ class CreateOrderTest < ActionDispatch::IntegrationTest
       click_link('Übernehmen')
 
       assert_equal 'New Client', find('#client_work_item_attributes_name')['value']
-      fill_in('client_work_item_attributes_shortname', with: 'NECL')
-      click_button 'Speichern'
+      within('.modal-dialog') do
+        fill_in('client_work_item_attributes_shortname', with: 'NECL')
+        click_button 'Speichern'
+      end
 
       assert_equal 'New Order', find('#order_work_item_attributes_name')['value']
 
@@ -520,20 +528,24 @@ class CreateOrderTest < ActionDispatch::IntegrationTest
 
   def create_client
     click_link('client_work_item_id_create_link')
-    fill_in('client_work_item_attributes_name', with: 'New Client')
-    fill_in('client_work_item_attributes_shortname', with: 'NECL')
-    click_button 'Speichern'
+    within('.modal-dialog') do
+      fill_in('client_work_item_attributes_name', with: 'New Client')
+      fill_in('client_work_item_attributes_shortname', with: 'NECL')
+      click_button 'Speichern'
+    end
   end
 
   def create_category
     click_link('category_work_item_id_create_link')
-    fill_in('work_item_name', with: 'New Category')
-    fill_in('work_item_shortname', with: 'NECA')
-    click_button 'Speichern'
+    within('.modal-dialog') do
+      fill_in('work_item_name', with: 'New Category')
+      fill_in('work_item_shortname', with: 'NECA')
+      click_button 'Speichern'
+    end
   end
 
   def click_add_contact
-    find("a.add_nested_fields_link[data-object-class='order_contact']").click
+    find("a.add_nested_fields_link[data-object-class='order_contact']").trigger("click")
   end
 
   def fill_mandatory_fields(with_name = true)

--- a/test/integration/plannings_orders_test.rb
+++ b/test/integration/plannings_orders_test.rb
@@ -283,13 +283,15 @@ class PlanningsOrdersTest < ActionDispatch::IntegrationTest
         click_button 'OK'
       end
 
-      page.assert_selector('div.-definitive', count: 12)
+      within('.planning-calendar') do
+        assert_selector('div.-definitive', count: 12)
+        drag(row_mark.all('.day')[5], row_pascal.all('.day')[9])
 
-      drag(row_mark.all('.day')[5], row_pascal.all('.day')[9])
-      page.assert_selector('.day.-selected', count: 10)
-      drag(row_pascal.all('.day.-selected')[2], row_mark.all('.day')[0], row_mark.all('*')[0])
-      row_mark.assert_selector('.day.-selected.-definitive:nth-child(2)')
-      page.assert_selector('.day.-definitive:not(.-selected)', count: 10, text: 100)
+        assert_selector('.day.-selected', count: 10)
+        drag(row_pascal.all('.day.-selected')[2], row_mark.all('.day')[0])
+
+        assert_selector('.day.-definitive', count: 10)
+      end
     end
   end
 
@@ -373,8 +375,9 @@ class PlanningsOrdersTest < ActionDispatch::IntegrationTest
     page.assert_selector('.planning-delete', visible: true)
 
     assert_difference('Planning.count', -2) do
-      find('.planning-delete').click
-      accept_confirmation('Bist du sicher, dass du die selektierte Planung löschen willst?')
+      accept_confirm('Bist du sicher, dass du die selektierte Planung löschen willst?') do
+        find('.planning-delete').click
+      end
       page.assert_selector('.planning-panel', visible: false)
       page.assert_selector('div.day.-definitive', count: 0)
     end
@@ -500,11 +503,13 @@ class PlanningsOrdersTest < ActionDispatch::IntegrationTest
   end
 
   def row_mark
-    find("#planning_row_employee_#{employees(:mark).id}_work_item_#{work_item_id}")
+    # TODO: without `sleep` I get "Node is either not visible or not an HTMLElement". Why??
+    @row_mark ||= find("#planning_row_employee_#{employees(:mark).id}_work_item_#{work_item_id}").tap { sleep 0.1 }
   end
 
   def row_pascal
-    find("#planning_row_employee_#{employees(:pascal).id}_work_item_#{work_item_id}")
+    # TODO: without `sleep` I get "Node is either not visible or not an HTMLElement". Why??
+    @row_pascal ||= find("#planning_row_employee_#{employees(:pascal).id}_work_item_#{work_item_id}").tap { sleep 0.1 }
   end
 
   def work_item_id


### PR DESCRIPTION
Change the capybara driver do cuprite. This hopefully makes the setup more reliable.
Additionally cuprite is supposed to be faster than selenium webdriver.