### PR TITLE
Update api docs

### DIFF
--- a/doc/user/api.md
+++ b/doc/user/api.md
@@ -32,7 +32,7 @@ Zusätzlich gibt es folgende Header um sich zu orientieren:
 
 ## API Dokumentation
 
-Die Dokumentation wird automatisch generiert.e Dokumentation ist unter [/api/docs] erreichbar.
+Die Dokumentation wird automatisch generiert uns ist unter [/api/docs] erreichbar.
 Auf dem Puzzletime Server ist sie im Swagger Webinterface unter [/api/docs] einsehbar.
 
 Die Swagger Spezifikation liegt unter [/api/docs/v1], diese kann in [Postman] und ähnliche tools importiert werden.

--- a/doc/user/api.md
+++ b/doc/user/api.md
@@ -32,7 +32,7 @@ Zusätzlich gibt es folgende Header um sich zu orientieren:
 
 ## API Dokumentation
 
-Die Dokumentation wird automatisch generiert uns ist unter [/api/docs] erreichbar.
+Die Dokumentation wird automatisch generiert und ist unter [/api/docs] erreichbar.
 Auf dem Puzzletime Server ist sie im Swagger Webinterface unter [/api/docs] einsehbar.
 
 Die Swagger Spezifikation liegt unter [/api/docs/v1], diese kann in [Postman] und ähnliche tools importiert werden.

--- a/doc/user/api.md
+++ b/doc/user/api.md
@@ -8,7 +8,7 @@ Es bietet Lesezugriff auf einige ausgewählte Resourcen.
 Alle implementierten Endpunkte sind mit [HTTP Basic Authentication][basic_auth] geschützt.
 
 Die Credentials sind in der aktuellen Implementierung global definiert und werden von allen API clients geteilt.
-Sie müssen auf dem Server über Umgebungsvariablen konfiguriert werden (siehe [/doc/development/03_deployment.md])
+Sie müssen auf dem Server über Umgebungsvariablen konfiguriert werden (siehe [/doc/development/02_deployment.md])
 
 ## Pagination
 

--- a/doc/user/api.md
+++ b/doc/user/api.md
@@ -40,6 +40,6 @@ Die Swagger Spezifikation liegt unter [/api/docs/v1], diese kann in [Postman] un
 [json:api]: https://jsonapi.org/
 [basic_auth]: https://tools.ietf.org/html/rfc2617
 [Postman]: https://www.getpostman.com/
-[/doc/development/03_deployment.md]: /doc/development/03_deployment.md
+[/doc/development/02_deployment.md]: /doc/development/02_deployment.md
 [/api/docs]: /api/docs
 [/api/docs/v1]: /api/docs/v1


### PR DESCRIPTION
Da ich kürzlich für ein anderes Projekt die API verwendet habe, ist mir ein kaputter Link in der API-Dokumentation aufgefallen. Ich habe diesen und auch einen kleinen typo der mir gerade aufgefallen ist, gefixt.