### PR TITLE
Show preview of charged hours when creating a new invoice (63117)

### DIFF
--- a/app/helpers/invoice_helper.rb
+++ b/app/helpers/invoice_helper.rb
@@ -21,6 +21,10 @@ module InvoiceHelper
     "#{f(entry.calculated_total_amount)} #{Settings.defaults.currency}"
   end
 
+  def format_invoice_calculated_total_hours(entry)
+    "#{f(entry.calculated_total_hours)} h"
+  end
+
   def format_billing_date(entry)
     l(entry.billing_date)
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -94,6 +94,10 @@ class Invoice < ActiveRecord::Base
     round_to_5_cents(total)
   end
 
+  def calculated_total_hours
+    positions.sum(&:total_hours)
+  end
+
   def billing_client
     billing_address.try(:client) ||
       order.billing_address.try(:client) ||

--- a/app/views/invoices/_filter_fields.html.haml
+++ b/app/views/invoices/_filter_fields.html.haml
@@ -27,4 +27,5 @@
 
 = f.labeled_static_field :calculated_total_amount, id: 'invoice_total_amount'
 
+= f.labeled_static_field :calculated_total_hours, id: 'invoice_total_hours'
 %hr

--- a/app/views/invoices/preview_total.js.haml
+++ b/app/views/invoices/preview_total.js.haml
@@ -5,3 +5,5 @@
 
 
 $("#invoice_total_amount").html('#{j(format_attr(entry, :calculated_total_amount))}');
+
+$("#invoice_total_hours").html('#{j(format_attr(entry, :calculated_total_hours))}');

--- a/config/locales/models.de-CH.yml
+++ b/config/locales/models.de-CH.yml
@@ -272,6 +272,7 @@ de-CH:
         billing_client_id: Rechnungskunde
         billing_date: Rechnungsdatum
         calculated_total_amount: Total Leistungen
+        calculated_total_hours: Geleistete Stunden
         due_date: Fälligkeitsdatum
         employees: Members
         grouping: Gruppierung

--- a/config/locales/models.de-DE.yml
+++ b/config/locales/models.de-DE.yml
@@ -235,6 +235,7 @@ de-DE:
         billing_client_id: Rechnungskunde
         billing_date: Rechnungsdatum
         calculated_total_amount: Total Leistungen
+        calculated_total_hours: Geleistete Stunden
         due_date: Fälligkeitsdatum
         employees: Members
         grouping: Gruppierung

--- a/test/controllers/invoices_controller_test.rb
+++ b/test/controllers/invoices_controller_test.rb
@@ -67,8 +67,10 @@ class InvoicesControllerTest < ActionController::TestCase
     get :preview_total, xhr: true, params: params.merge(format: :js)
 
     preview_value = response.body[/html\('(.+) #{Settings.defaults.currency}'\)/, 1].to_f
+    preview_value_hours = response.body[/html\('(.+) h'\)/, 1].to_f
 
     assert_equal(entry.calculated_total_amount, preview_value)
+    assert_equal(entry.calculated_total_hours, preview_value_hours)
   end
 
   test 'GET billing_addresses' do

--- a/test/integration/invoice_form_test.rb
+++ b/test/integration/invoice_form_test.rb
@@ -49,6 +49,13 @@ class NewInvoiceTest < ActionDispatch::IntegrationTest
     assert_match expected_total, text_on_page
   end
 
+  test 'sets calculated total hours on page load' do
+    expected_total = "#{delimited_number(billable_hours)} h"
+    text_on_page = find('#invoice_total_hours').text
+
+    assert_match expected_total, text_on_page
+  end
+
   test 'lists only employees with ordertimes on page load' do
     all(:name, 'invoice[employee_ids][]').map(&:value)
 
@@ -110,6 +117,13 @@ class NewInvoiceTest < ActionDispatch::IntegrationTest
 
   test 'check employee checkbox updates calculated total' do
     assert_change -> { find('#invoice_total_amount').text } do
+      find_field("invoice_employee_ids_#{employees(:mark).id}").click
+      sleep(0.5) # give the xhr request some time to complete
+    end
+  end
+
+  test 'check employee checkbox updates calculated hours' do
+    assert_change -> { find('#invoice_total_hours').text } do
       find_field("invoice_employee_ids_#{employees(:mark).id}").click
       sleep(0.5) # give the xhr request some time to complete
     end


### PR DESCRIPTION
When creating a new invoice, the number of hours that are charged is displayed as a preview, just below the preview of the amount of money that will be charged.