### PR TITLE
Fix various bugs related to the creation of a new invoice

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -45,6 +45,7 @@
 #= require expenses
 #= require expense_reviews
 #= require meal_compensations
+#= require invoices
 #= require turbolinks
 
 app = window.App ||= {}

--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -124,8 +124,8 @@ $(document).on('ajax:error', (event, xhr, status, error) ->
 
 
 ################################################################
-# only bind events for non-document elements on turbolinks:load
-$(document).on('turbolinks:load', ->
+# only bind events for non-document elements on turbolinks:load and ajax:success
+$(document).on('turbolinks:load ajax:success', ->
   # wire up selectize
   $('select.searchable:not([multiple])').selectize(selectOnTab: true)
   $('select[multiple].searchable').selectize(plugins: ['remove_button'], selectOnTab: true)

--- a/app/assets/javascripts/invoices.js.coffee
+++ b/app/assets/javascripts/invoices.js.coffee
@@ -13,9 +13,6 @@ app.invoices = new class
     $('#invoice_period_from,#invoice_period_to')
       .datepicker('option', 'disabled', $('#period_shortcut').val())
 
-    # $('#period_shortcut').closest('.form-group')
-    #   .css('visibility', if !$('#invoice_period_to').val() && !$('#invoice_period_from').val() then 'visible' else 'hidden')
-
 $(document).on('change', '#invoice_period_from,#invoice_period_to,#period_shortcut', ->
   app.invoices.init()
 )

--- a/app/assets/javascripts/invoices.js.coffee
+++ b/app/assets/javascripts/invoices.js.coffee
@@ -1,0 +1,25 @@
+#  Copyright (c) 2006-2017, Puzzle ITC GmbH. This file is part of
+#  PuzzleTime and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/puzzle/puzzletime.
+
+app = window.App ||= {}
+
+app.invoices = new class
+  init: ->
+    @dateChanged()
+
+  dateChanged: ->
+    $('#invoice_period_from,#invoice_period_to')
+      .datepicker('option', 'disabled', $('#period_shortcut').val())
+
+    # $('#period_shortcut').closest('.form-group')
+    #   .css('visibility', if !$('#invoice_period_to').val() && !$('#invoice_period_from').val() then 'visible' else 'hidden')
+
+$(document).on('change', '#invoice_period_from,#invoice_period_to,#period_shortcut', ->
+  app.invoices.init()
+)
+
+$(document).on('turbolinks:load', ->
+  app.invoices.init()
+)

--- a/app/assets/javascripts/invoices.js.coffee
+++ b/app/assets/javascripts/invoices.js.coffee
@@ -10,10 +10,12 @@ app.invoices = new class
     @dateChanged()
 
   dateChanged: ->
-    $('#invoice_period_from,#invoice_period_to')
-      .datepicker('option', 'disabled', $('#period_shortcut').val())
+    $('#invoice_period_from,#invoice_period_to').each ->
+      val = $(this).val()
+      $(this).datepicker('option', 'disabled', $('#period_shortcut').val())
+      $(this).val(val)
 
-$(document).on('change', '#invoice_period_from,#invoice_period_to,#period_shortcut', ->
+$(document).on('change', '#period_shortcut', ->
   app.invoices.init()
 )
 

--- a/app/controllers/concerns/filterable.rb
+++ b/app/controllers/concerns/filterable.rb
@@ -27,4 +27,16 @@ module Filterable
       end
     end
   end
+
+  def filter_entries_allow_custom_mappings_by(entries, custom_key_mappings, *keys)
+    (custom_key_mappings.keys + keys).inject(entries) do |filtered, key|
+      if custom_key_mappings[key].present? && params[key].present?
+        filtered.where(custom_key_mappings[key] => params[key])
+      elsif params[key].present?
+        filtered.where(key => params[key])
+      else
+        filtered
+      end
+    end
+  end
 end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -120,9 +120,9 @@ class InvoicesController < CrudController
 
     attrs[:grouping] = 'manual' if params[:manual_invoice]
     attrs[:employee_ids] = Array(attrs[:employee_ids]) << params[:employee_id] if params[:employee_id].present?
-    return if params[:work_item_id].blank?
+    return if params[:work_item_ids].blank?
 
-    attrs[:work_item_ids] = Array(attrs[:work_item_ids]) + params[:work_item_id]
+    attrs[:work_item_ids] = Array(attrs[:work_item_ids]) + params[:work_item_ids]
   end
 
   def init_default_attrs(attrs)

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -113,15 +113,11 @@ class InvoicesController < CrudController
   end
 
   def copy_attrs_from_params(attrs)
-    if params[:period_shortcut].present?
-      period = build_period
-      attrs[:period_from] ||= period.start_date
-      attrs[:period_to] ||= period.end_date
-    else
-      attrs[:period_from] ||= params[:start_date]
-      attrs[:period_to] ||= params[:end_date]
-    end
-    set_period # sets @period based on params[:period_shortcut] if set, else based on params[:start_date] and params[:end_date]
+    set_period
+    
+    attrs[:period_from] ||= @period.start_date
+    attrs[:period_to] ||= @period.end_date
+
     attrs[:grouping] = 'manual' if params[:manual_invoice]
     attrs[:employee_ids] = Array(attrs[:employee_ids]) << params[:employee_id] if params[:employee_id].present?
     return if params[:work_item_id].blank?

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -122,7 +122,7 @@ class InvoicesController < CrudController
     attrs[:employee_ids] = Array(attrs[:employee_ids]) << params[:employee_id] if params[:employee_id].present?
     return if params[:work_item_id].blank?
 
-    attrs[:work_item_ids] = Array(attrs[:work_item_ids]) << params[:work_item_id]
+    attrs[:work_item_ids] = Array(attrs[:work_item_ids]) + params[:work_item_id]
   end
 
   def init_default_attrs(attrs)

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -121,7 +121,7 @@ class InvoicesController < CrudController
       attrs[:period_from] ||= params[:start_date]
       attrs[:period_to] ||= params[:end_date]
     end
-    set_period # sets @period based on start_date and end_date params
+    set_period # sets @period based on params[:period_shortcut] if set, else based on params[:start_date] and params[:end_date]
     attrs[:grouping] = 'manual' if params[:manual_invoice]
     attrs[:employee_ids] = Array(attrs[:employee_ids]) << params[:employee_id] if params[:employee_id].present?
     return if params[:work_item_id].blank?

--- a/app/controllers/order_services_controller.rb
+++ b/app/controllers/order_services_controller.rb
@@ -75,8 +75,9 @@ class OrderServicesController < ApplicationController
   end
 
   def prepare_report_header
-    work_item_id = params[:work_item_id].presence || order.work_item_id
-    @work_item = WorkItem.find(work_item_id)
+    params[:work_item_id] ||= order.worktimes.select(:work_item_id).distinct.pluck(:work_item_id)
+    work_item_id = params[:work_item_id]
+    @work_items = WorkItem.find(work_item_id)
     @employee = Employee.find(params[:employee_id]) if params[:employee_id].present?
     set_period_with_invoice
   end

--- a/app/controllers/order_services_controller.rb
+++ b/app/controllers/order_services_controller.rb
@@ -17,7 +17,7 @@ class OrderServicesController < ApplicationController
   include WorktimesReport
   include WorktimesCsv
 
-  self.remember_params = %w[start_date end_date period_shortcut employee_id work_item_id ticket
+  self.remember_params = %w[start_date end_date period_shortcut employee_id work_item_ids ticket
                             billable invoice_id]
 
   before_action :order
@@ -55,7 +55,7 @@ class OrderServicesController < ApplicationController
                    .order(:work_date)
                    .in_period(period)
     entries = filter_entries_allow_empty_by(entries, EMPTY, :ticket, :invoice_id)
-    filter_entries_by(entries, :employee_id, :work_item_id, :billable, :meal_compensation)
+    filter_entries_allow_custom_mappings_by(entries, { work_item_ids: :work_item_id }, :employee_id, :billable, :meal_compensation)
   end
 
   def worktimes_csv_filename
@@ -75,9 +75,8 @@ class OrderServicesController < ApplicationController
   end
 
   def prepare_report_header
-    params[:work_item_id] ||= order.worktimes.select(:work_item_id).distinct.pluck(:work_item_id)
-    work_item_id = params[:work_item_id]
-    @work_items = WorkItem.find(work_item_id)
+    params[:work_item_ids] ||= order.worktimes.select(:work_item_id).distinct.pluck(:work_item_id)
+    @work_items = WorkItem.find(params[:work_item_ids])
     @employee = Employee.find(params[:employee_id]) if params[:employee_id].present?
     set_period_with_invoice
   end

--- a/app/domain/order/services/csv_filename_generator.rb
+++ b/app/domain/order/services/csv_filename_generator.rb
@@ -35,7 +35,7 @@ class Order
       def accounting_post_shortnames
         return if params[:work_item_id].blank?
 
-        WorkItem.find(params[:work_item_id]).path_shortnames
+        params[:work_item_id].map { |id| WorkItem.find(id).path_shortnames }.join('_')
       end
 
       def employee_shortname

--- a/app/domain/order/services/csv_filename_generator.rb
+++ b/app/domain/order/services/csv_filename_generator.rb
@@ -33,9 +33,9 @@ class Order
       end
 
       def accounting_post_shortnames
-        return if params[:work_item_id].blank?
+        return if params[:work_item_ids].blank?
 
-        params[:work_item_id].map { |id| WorkItem.find(id).path_shortnames }.join('_')
+        params[:work_item_ids].map { |id| WorkItem.find(id).path_shortnames }.join('_')
       end
 
       def employee_shortname

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -14,7 +14,7 @@ module NavigationHelper
   # Also you can give it an exception url, that let's you ignore
   # a specific url that would otherwise match.
   def nav(label, url, *active_for, except: '')
-    options = active_for.extract_options!
+    options = active_for.extract_options!.merge(data: { turbolinks: false })
     active_class = nav_active_class(url, active_for, except)
 
     content_tag(

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -12,6 +12,9 @@
   = hidden_field_tag(:order_id, order.id)
   = f.labeled_input_field :period_from, caption: 'Leistungsperiode von'
   = f.labeled_input_field :period_to
+  = f.labeled :period_shortcut_selection, span: 1 do
+    = select_tag(:period_shortcut, options_from_collection_for_select(predefined_past_period_options, :id, :to_s, @period&.shortcut || ''), {prompt: 'benutzerdefiniert', data: {}, :class=>"form-control"})
+    
   = f.labeled :manual_invoice do
     .checkbox
       %label
@@ -36,5 +39,5 @@
       = render 'billing_addresses_fields'
 
 - content_for(:javascript) do
-  new window.App.FormUpdater("#{preview_total_order_invoices_path(id: entry.id, format: :js)}", 'change', 'form.invoice', 'form.invoice');
-  new window.App.FormUpdater("#{filter_fields_order_invoices_path(id: entry.id, format: :js)}", 'change', 'form.invoice', 'input#invoice_period_from', 'input#invoice_period_to');
+  new window.App.FormUpdater("#{preview_total_order_invoices_path(id: entry.id, format: :js)}", 'change', 'form.invoice', 'form.invoice', 'select#period_shortcut');
+  new window.App.FormUpdater("#{filter_fields_order_invoices_path(id: entry.id, format: :js)}", 'change', 'form.invoice', 'input#invoice_period_from', 'input#invoice_period_to', 'select#period_shortcut');

--- a/app/views/invoices/_form.html.haml
+++ b/app/views/invoices/_form.html.haml
@@ -13,7 +13,9 @@
   = f.labeled_input_field :period_from, caption: 'Leistungsperiode von'
   = f.labeled_input_field :period_to
   = f.labeled :period_shortcut_selection, span: 1 do
-    = select_tag(:period_shortcut, options_from_collection_for_select(predefined_past_period_options, :id, :to_s, @period&.shortcut || ''), {prompt: 'benutzerdefiniert', data: {}, :class=>"form-control"})
+    = select_tag  :period_shortcut, 
+                  options_from_collection_for_select(predefined_past_period_options, :id, :to_s, @period&.shortcut || ''), 
+                  {prompt: 'benutzerdefiniert', data: {}, :class=>"form-control"}
     
   = f.labeled :manual_invoice do
     .checkbox
@@ -39,5 +41,11 @@
       = render 'billing_addresses_fields'
 
 - content_for(:javascript) do
-  new window.App.FormUpdater("#{preview_total_order_invoices_path(id: entry.id, format: :js)}", 'change', 'form.invoice', 'form.invoice', 'select#period_shortcut');
-  new window.App.FormUpdater("#{filter_fields_order_invoices_path(id: entry.id, format: :js)}", 'change', 'form.invoice', 'input#invoice_period_from', 'input#invoice_period_to', 'select#period_shortcut');
+  var filter_fields_trigger = new window.App.FormUpdaterTrigger('change', 'input#invoice_period_from', 'input#invoice_period_to', 'select#period_shortcut')
+  var calculate_total_trigger = new window.App.FormUpdaterTrigger('change', 'form.invoice')
+
+  var filter_fields_action = new window.App.FormUpdaterAction("#{filter_fields_order_invoices_path(id: entry.id, format: :js)}", 'form.invoice')
+  var calculate_total_action = new window.App.FormUpdaterAction("#{preview_total_order_invoices_path(id: entry.id, format: :js)}", 'form.invoice')
+
+  new window.App.FormUpdater(filter_fields_trigger, filter_fields_action, calculate_total_action);
+  new window.App.FormUpdater(calculate_total_trigger, calculate_total_action);

--- a/app/views/order_services/_actions.html.haml
+++ b/app/views/order_services/_actions.html.haml
@@ -10,15 +10,15 @@
               data: { submit_form: '#worktimes' })
 
 = action_link(action_icon('export', 'CSV Export'),
-              params.to_unsafe_h.merge(action: :export_worktimes_csv, only_path: true))
+              params.to_unsafe_h.merge(action: :export_worktimes_csv, only_path: true), :data => {turbolinks: "false" })
 
 = action_link(action_icon('time', 'Zeitrapport erstellen'),
-              params.to_unsafe_h.merge(action: :compose_report, only_path: true))
+              params.to_unsafe_h.merge(action: :compose_report, only_path: true), :data => {turbolinks: "false" })
 
 - if !@order.status.closed && can?(:create_invoices, @order)
   = action_link(action_icon('document', 'Rechnung erstellen'),
-                new_order_invoice_path(@order, params.permit(:start_date, :end_date, :employee_id, :work_item_id, :ticket)))
+                new_order_invoice_path(@order, params.permit(:start_date, :end_date, :employee_id, :work_item_id, :ticket)), :data => {turbolinks: "false" })
 
 - if @user.management
   = action_link(action_icon('add', 'Fremderfassung'),
-                new_ordertime_path(other: 1, back_url: url_for(returning: true)))
+                new_ordertime_path(other: 1, back_url: url_for(returning: true)), :data => {turbolinks: "false" })

--- a/app/views/order_services/_actions.html.haml
+++ b/app/views/order_services/_actions.html.haml
@@ -17,7 +17,7 @@
 
 - if !@order.status.closed && can?(:create_invoices, @order)
   = action_link(action_icon('document', 'Rechnung erstellen'),
-                new_order_invoice_path(@order, params.permit(:start_date, :end_date, :employee_id, :work_item_id, :ticket)), :data => {turbolinks: "false" })
+                new_order_invoice_path(@order, params.permit(:start_date, :end_date, :employee_id, :work_item_id, :ticket, :period_shortcut)), :data => {turbolinks: "false" })
 
 - if @user.management
   = action_link(action_icon('add', 'Fremderfassung'),

--- a/app/views/order_services/_actions.html.haml
+++ b/app/views/order_services/_actions.html.haml
@@ -17,7 +17,7 @@
 
 - if !@order.status.closed && can?(:create_invoices, @order)
   = action_link(action_icon('document', 'Rechnung erstellen'),
-                new_order_invoice_path(@order, params.permit(:start_date, :end_date, :employee_id, :work_item_id, :ticket, :period_shortcut)), :data => {turbolinks: "false" })
+                new_order_invoice_path(@order, params.permit(:start_date, :end_date, :employee_id, {work_item_id: []}, :ticket, :period_shortcut)), :data => {turbolinks: "false" })
 
 - if @user.management
   = action_link(action_icon('add', 'Fremderfassung'),

--- a/app/views/order_services/_actions.html.haml
+++ b/app/views/order_services/_actions.html.haml
@@ -17,7 +17,7 @@
 
 - if !@order.status.closed && can?(:create_invoices, @order)
   = action_link(action_icon('document', 'Rechnung erstellen'),
-                new_order_invoice_path(@order, params.permit(:start_date, :end_date, :employee_id, {work_item_id: []}, :ticket, :period_shortcut)), :data => {turbolinks: "false" })
+                new_order_invoice_path(@order, params.permit(:start_date, :end_date, :employee_id, {work_item_ids: []}, :ticket, :period_shortcut)), :data => {turbolinks: "false" })
 
 - if @user.management
   = action_link(action_icon('add', 'Fremderfassung'),

--- a/app/views/order_services/_filters.html.haml
+++ b/app/views/order_services/_filters.html.haml
@@ -4,7 +4,7 @@
 -#  https://github.com/puzzle/puzzletime.
 
 
-= form_tag(nil, method: :get, id: 'order_services_filter_form', class: 'form-inline', role: 'filter') do
+= form_tag(nil, method: :get, id: 'order_services_filter_form', class: 'form-inline', role: 'filter', remote: true) do
   = hidden_field_tag :page, 1
 
   = direct_filter_date(:start_date, 'Von', @period.start_date)

--- a/app/views/order_services/_filters.html.haml
+++ b/app/views/order_services/_filters.html.haml
@@ -4,7 +4,7 @@
 -#  https://github.com/puzzle/puzzletime.
 
 
-= form_tag(nil, method: :get, id: 'order_services_filter_form', class: 'form-inline', role: 'filter', remote: true) do
+= form_tag(nil, method: :get, id: 'order_services_filter_form', class: 'form-inline', role: 'filter') do
   = hidden_field_tag :page, 1
 
   = direct_filter_date(:start_date, 'Von', @period.start_date)

--- a/app/views/order_services/_value_filters.html.haml
+++ b/app/views/order_services/_value_filters.html.haml
@@ -5,7 +5,7 @@
 
 
 = direct_filter_select(:employee_id, 'Members', @employees)
-= direct_filter_select(:work_item_id, 'Buchungsposition', @accounting_posts, class: 'searchable', multiple: true)
+= direct_filter_select(:work_item_ids, 'Buchungsposition', @accounting_posts, class: 'searchable', multiple: true)
 = direct_filter_select(:ticket, 'Ticket', @tickets, value_method: :to_s)
 = direct_filter_select(:billable, 'Verrechenbar', yes_no_options)
 - if Settings.meal_compensation.active

--- a/app/views/order_services/_value_filters.html.haml
+++ b/app/views/order_services/_value_filters.html.haml
@@ -5,7 +5,7 @@
 
 
 = direct_filter_select(:employee_id, 'Members', @employees)
-= direct_filter_select(:work_item_id, 'Buchungsposition', @accounting_posts)
+= direct_filter_select(:work_item_id, 'Buchungsposition', @accounting_posts, class: 'searchable', multiple: true)
 = direct_filter_select(:ticket, 'Ticket', @tickets, value_method: :to_s)
 = direct_filter_select(:billable, 'Verrechenbar', yes_no_options)
 - if Settings.meal_compensation.active

--- a/app/views/worktimes_report/_report_config.html.haml
+++ b/app/views/worktimes_report/_report_config.html.haml
@@ -11,8 +11,8 @@
 = form_tag({ action: 'report' }, method: 'get') do
   - %w(evaluation start_date end_date period_shortcut category_id division_id employee_id ticket invoice_id billable).each do |p|
     = hidden_field_tag p, params[p] if params[p]
-  - params['work_item_id'].each do |v|
-    = hidden_field_tag 'work_item_id[]', v
+  - params['work_item_ids'].each do |v|
+    = hidden_field_tag 'work_item_ids[]', v
 
   - if billable_option
     .checkbox

--- a/app/views/worktimes_report/_report_config.html.haml
+++ b/app/views/worktimes_report/_report_config.html.haml
@@ -9,9 +9,10 @@
 %h4 Einstellungen
 
 = form_tag({ action: 'report' }, method: 'get') do
-
-  - %w(evaluation start_date end_date period_shortcut category_id division_id work_item_id employee_id ticket invoice_id billable).each do |p|
+  - %w(evaluation start_date end_date period_shortcut category_id division_id employee_id ticket invoice_id billable).each do |p|
     = hidden_field_tag p, params[p] if params[p]
+  - params['work_item_id'].each do |v|
+    = hidden_field_tag 'work_item_id[]', v
 
   - if billable_option
     .checkbox

--- a/app/views/worktimes_report/_report_header.html.haml
+++ b/app/views/worktimes_report/_report_header.html.haml
@@ -8,11 +8,18 @@
   %tr
     %td Kunde
     %td
-      %b= @work_item.top_item.client.label
+      %b= @work_items[0].top_item.client.label
   %tr
     %td Auftrag
     %td
-      %b= @work_item.label_ancestry
+      %b= @order.label
+  -if params[:show_work_item] || params[:action] == 'compose_report'
+    %tr
+      %td Buchungspositionen
+      %td
+        - @work_items.each do |item|
+          %b= item.name
+          %br
   - if @employee
     %tr
       %td Member

--- a/config/locales/models.de-CH.yml
+++ b/config/locales/models.de-CH.yml
@@ -284,6 +284,7 @@ de-CH:
         period: Leistungsperiode
         period_from: von
         period_to: bis
+        period_shortcut_selection: Vergangenen Monat wählen
         reference: Referenz
         status: Status
         total_amount: Rechnungsbetrag

--- a/config/locales/models.de-DE.yml
+++ b/config/locales/models.de-DE.yml
@@ -247,6 +247,7 @@ de-DE:
         period: Leistungsperiode
         period_from: von
         period_to: bis
+        period_shortcut_selection: Vergangenen Monat wählen
         reference: Referenz
         status: Status
         total_amount: Rechnungsbetrag

--- a/test/integration/invoice_form_test.rb
+++ b/test/integration/invoice_form_test.rb
@@ -177,6 +177,55 @@ class NewInvoiceTest < ActionDispatch::IntegrationTest
     assert find('#billing_addresses').has_content?('Eigerplatz')
   end
 
+  test 'passing start / end date params or a period shortcut sets date fields' do
+    reload({ start_date: '01.11.2006', end_date: '08.12.2006' })
+
+    assert_equal '01.11.2006', find('#invoice_period_from')['value']
+    assert_equal '08.12.2006', find('#invoice_period_to')['value']
+
+    reload({ period_shortcut: '-1m' })
+    period = Period.parse('-1m')
+
+    assert_equal Period.parse_date(period.start_date), Period.parse_date(find('#invoice_period_from')['value'])
+    assert_equal Period.parse_date(period.end_date), Period.parse_date(find('#invoice_period_to')['value'])
+  end
+
+  test 'setting the period shortcut disables the date fields, unsetting it enables the date fields' do
+    put_period_shortcut('-1m')
+
+    assert find('#invoice_period_from')['disabled']
+    assert find('#invoice_period_to')['disabled']
+
+    clear_period_shortcut
+
+    assert_not find('#invoice_period_from')['disabled']
+    assert_not find('#invoice_period_to')['disabled']
+  end
+
+  test 'set to period_shortcut updates employee checkboxes' do
+    assert has_css?('#employee_checkboxes', text: 'Waber Mark')
+
+    put_period_shortcut('-1m')
+
+    assert_not has_css?('#employee_checkboxes', text: 'Waber Mark')
+
+    clear_period_shortcut
+
+    assert has_css?('#employee_checkboxes', text: 'Waber Mark')
+  end
+
+  test 'set to period_shortcut updates work_items checkboxes' do
+    assert has_css?('#work_item_checkboxes', text: 'STOP-WEB: Webauftritt')
+
+    put_period_shortcut('-1m')
+
+    assert_not has_css?('#work_item_checkboxes', text: 'STOP-WEB: Webauftritt')
+
+    clear_period_shortcut
+
+    assert has_css?('#work_item_checkboxes', text: 'STOP-WEB: Webauftritt')
+  end
+
   def order
     orders(:webauftritt)
   end
@@ -212,6 +261,18 @@ class NewInvoiceTest < ActionDispatch::IntegrationTest
     fill_in(label, with: date_string)
     page.find('#ui-datepicker-div .ui-datepicker-current-day a').click
     sleep(0.5) # give the xhr request some time to complete
+  end
+
+  def put_period_shortcut(period_shortcut)
+    find('#period_shortcut').click
+    find("option[value=\"#{period_shortcut}\"]").select_option
+    sleep(0.5)
+  end
+
+  def clear_period_shortcut
+    find('#period_shortcut').click
+    find("option[value='']").select_option
+    sleep(0.5)
   end
 
   # asserts that the checkboxes match the models by value/id and the checked state


### PR DESCRIPTION
Fixes the related bugs 63817, 63819, 63820 and then enabled by this fix, implements 63118 and 63119.

This essentially involves the following parts:
- [63817, 63819, 63820] deactivating turbolinks for navigation between different tabs in orders, as this introduces buggy behaviour when using the back button of the browser
- [63118] also passing the period_shortcut as param
- [63119] adding a button to select a period_shortcut in the creation of a new invoice. Debug an existing race condition.

All these tickets are tightly connected, why I combine them in one PR. If these should be separated either way, I'm happy to do so. 