### PR TITLE
split up orders into three tabs: all, open, closed (63114)

### DIFF
--- a/app/assets/javascripts/reports_orders.js.coffee
+++ b/app/assets/javascripts/reports_orders.js.coffee
@@ -13,6 +13,8 @@ app.reportsOrders = new class
   dateFilterChanged: ->
     $('.order_reports form[role="filter"]').find('#start_date,#end_date')
       .datepicker('option', 'disabled', $('#period_shortcut').val())
+    if $('#period_shortcut').val()
+      $('.order_reports form[role="filter"]').find('#start_date,#end_date').val("")
 
 $(document).on('ajax:success', '.order_reports form[role="filter"]', ->
   app.reportsOrders.init()

--- a/app/controllers/order_reports_controller.rb
+++ b/app/controllers/order_reports_controller.rb
@@ -25,12 +25,12 @@ class OrderReportsController < ApplicationController
         params[:department_id] = @user.department_id
         case params[:status_preselection]
         when nil, ''
-          params.merge!(period_shortcut: '0m')
+          params.reverse_merge!(period_shortcut: '0m')
         when 'closed'
-          params.merge!(period_shortcut: '-1q')
+          params.reverse_merge!(period_shortcut: '-1q')
         when 'not_closed'
-          params.merge!(period_shortcut: '0m',
-                        status_id: @order_status.where(closed: false).where(default: true).pick(:id))
+          params.reverse_merge!(period_shortcut: '0m',
+                                status_id: @order_status.where(closed: false).where(default: true).pick(:id))
         end
       end
       format.js do

--- a/app/controllers/order_reports_controller.rb
+++ b/app/controllers/order_reports_controller.rb
@@ -17,8 +17,6 @@ class OrderReportsController < ApplicationController
   before_action :authorize_class
 
   def index
-    set_period
-    @report = Order::Report.new(@period, params)
     respond_to do |format|
       format.html do
         set_filter_values
@@ -32,11 +30,17 @@ class OrderReportsController < ApplicationController
           params.reverse_merge!(period_shortcut: '0m',
                                 status_id: @order_status.where(closed: false).where(default: true).pick(:id))
         end
+        set_period
+        @report = Order::Report.new(@period, params)
       end
       format.js do
+        set_period
+        @report = Order::Report.new(@period, params)
         set_filter_values
       end
       format.csv do
+        set_period
+        @report = Order::Report.new(@period, params)
         send_data(Order::Report::Csv.new(@report).generate,
                   type: 'text/csv; charset=utf-8; header=present')
       end

--- a/app/controllers/order_reports_controller.rb
+++ b/app/controllers/order_reports_controller.rb
@@ -22,6 +22,16 @@ class OrderReportsController < ApplicationController
     respond_to do |format|
       format.html do
         set_filter_values
+        params[:department_id] = @user.department_id
+        case params[:status_preselection]
+        when nil, ''
+          params.merge!(period_shortcut: '0m')
+        when 'closed'
+          params.merge!(period_shortcut: '-1q')
+        when 'not_closed'
+          params.merge!(period_shortcut: '0m',
+                        status_id: @order_status.where(closed: false).where(default: true).pick(:id))
+        end
       end
       format.js do
         set_filter_values

--- a/app/controllers/order_reports_controller.rb
+++ b/app/controllers/order_reports_controller.rb
@@ -15,7 +15,6 @@ class OrderReportsController < ApplicationController
                             major_risk_value]
 
   before_action :authorize_class
-  before_action :show_without_hours
 
   def index
     set_period
@@ -35,10 +34,6 @@ class OrderReportsController < ApplicationController
   end
 
   private
-
-  def show_without_hours
-    params[:without_hours] = true if params[:status_preselection].presence
-  end
 
   def set_filter_values
     @departments = Department.list

--- a/app/controllers/order_reports_controller.rb
+++ b/app/controllers/order_reports_controller.rb
@@ -37,7 +37,7 @@ class OrderReportsController < ApplicationController
   private
 
   def show_without_hours
-    params[:without_hours] = true if params[:closed].presence
+    params[:without_hours] = true if params[:status_preselection].presence
   end
 
   def set_filter_values

--- a/app/controllers/order_reports_controller.rb
+++ b/app/controllers/order_reports_controller.rb
@@ -18,29 +18,29 @@ class OrderReportsController < ApplicationController
 
   def index
     respond_to do |format|
+      set_period
+      @report = Order::Report.new(@period, params)
       format.html do
         set_filter_values
-        params[:department_id] ||= @user.department_id
-        case params[:status_preselection]
-        when nil, ''
-          params.reverse_merge!(period_shortcut: '0m')
-        when 'closed'
-          params.reverse_merge!(period_shortcut: '-1q')
-        when 'not_closed'
-          params.reverse_merge!(period_shortcut: '0m',
-                                status_id: @order_status.where(closed: false).where(default: true).pick(:id))
+        unless @report.filters_defined?
+          params[:department_id] ||= @user.department_id
+          case params[:status_preselection]
+          when nil, ''
+            params.reverse_merge!(period_shortcut: '0m')
+          when 'closed'
+            params.reverse_merge!(period_shortcut: '-1q')
+          when 'not_closed'
+            params.reverse_merge!(period_shortcut: '0m',
+                                  status_id: @order_status.where(closed: false).where(default: true).pick(:id))
+          end
+          set_period
+          @report = Order::Report.new(@period, params)
         end
-        set_period
-        @report = Order::Report.new(@period, params)
       end
       format.js do
-        set_period
-        @report = Order::Report.new(@period, params)
         set_filter_values
       end
       format.csv do
-        set_period
-        @report = Order::Report.new(@period, params)
         send_data(Order::Report::Csv.new(@report).generate,
                   type: 'text/csv; charset=utf-8; header=present')
       end

--- a/app/controllers/order_reports_controller.rb
+++ b/app/controllers/order_reports_controller.rb
@@ -20,7 +20,7 @@ class OrderReportsController < ApplicationController
     respond_to do |format|
       format.html do
         set_filter_values
-        params[:department_id] = @user.department_id
+        params[:department_id] ||= @user.department_id
         case params[:status_preselection]
         when nil, ''
           params.reverse_merge!(period_shortcut: '0m')

--- a/app/domain/order/report.rb
+++ b/app/domain/order/report.rb
@@ -133,7 +133,7 @@ class Order
     end
 
     def show_without_hours?
-      params[:without_hours].presence || false
+      params[:without_hours] == 'true'
     end
 
     def booked_hours?(post_hours)

--- a/app/domain/order/report.rb
+++ b/app/domain/order/report.rb
@@ -93,7 +93,7 @@ class Order
                'accounting_posts.work_item_id = ANY (work_items.path_ids)')
         .where(accounting_posts: { id: accounting_posts.collect(&:keys).flatten })
 
-      accounting_post_hours = accounting_post_hours.in_period(period) if params[:status_preselection].blank?
+      accounting_post_hours = accounting_post_hours.in_period(period) if params[:status_preselection].blank? || params[:status_preselection] == 'not_closed'
 
       accounting_post_hours
         .group('accounting_posts.id, worktimes.billable')
@@ -109,7 +109,7 @@ class Order
     def load_invoices(orders)
       invoices = Invoice.where(order_id: orders.collect(&:id))
 
-      invoices = invoices.where(period.where_condition('billing_date')) if params[:status_preselection].blank?
+      invoices = invoices.where(period.where_condition('billing_date')) if params[:status_preselection].blank? || params[:status_preselection] == 'not_closed'
 
       invoices
         .group('order_id')

--- a/app/domain/order/report.rb
+++ b/app/domain/order/report.rb
@@ -162,12 +162,13 @@ class Order
 
     def filter_by_closed(orders)
       case params[:status_preselection]
-      when nil, ""
+      when nil, ''
         orders
       when 'closed'
+        params[:department_id] = @user.department_id
         orders.where(order_statuses: { closed: true })
-              .where(period.where_condition('closed_at')) 
-      when 'in_progress'
+              .where(period.where_condition('closed_at'))
+      when 'not_closed'
         orders.where(order_statuses: { closed: false })
       end
     end

--- a/app/domain/order/report.rb
+++ b/app/domain/order/report.rb
@@ -165,7 +165,6 @@ class Order
       when nil, ''
         orders
       when 'closed'
-        params[:department_id] = @user.department_id
         orders.where(order_statuses: { closed: true })
               .where(period.where_condition('closed_at'))
       when 'not_closed'

--- a/app/domain/order/report.rb
+++ b/app/domain/order/report.rb
@@ -161,14 +161,15 @@ class Order
     end
 
     def filter_by_closed(orders)
-      return orders if params[:status_preselection].blank?
-      if params[:status_preselection] == 'closed'
-        return orders.where(order_statuses: { closed: true })
-                     .where(period.where_condition('closed_at')) 
-      end
-      return unless params[:status_preselection] == 'in_progress'
+      case params[:status_preselection]
+      when nil, ""
+        orders
+      when 'closed'
+        orders.where(order_statuses: { closed: true })
+              .where(period.where_condition('closed_at')) 
+      when 'in_progress'
         orders.where(order_statuses: { closed: false })
-      
+      end
     end
 
     def filter_by_uncertainty(orders, attr)

--- a/app/views/order_reports/_filters.html.haml
+++ b/app/views/order_reports/_filters.html.haml
@@ -63,7 +63,7 @@
                          'Aufträge ohne Zeitbuchungen',
                          [IdValue.new('true', 'anzeigen'), IdValue.new('false', 'verbergen')],
                          class: 'searchable',
-                         value: params[:without_hours] ||= true)
+                         value: params[:without_hours] || false)
 
   = direct_filter_select(:responsible_id,
                          'Verantwortlich',

--- a/app/views/order_reports/_filters.html.haml
+++ b/app/views/order_reports/_filters.html.haml
@@ -6,16 +6,17 @@
 
 = form_tag(nil, method: :get, class: 'form-inline', role: 'filter', remote: true, data: { spin: true }) do
   = hidden_field_tag :page, 1
-  = hidden_field_tag :closed, params[:closed]
+  -# = hidden_field_tag :status_preselection, params[:status_preselection]
+  = hidden_field_tag :status_preselection, params[:status_preselection]
 
-  - start_label = params[:closed].present? ? 'Abgeschlossen zwischen' : 'Zeiten von'
-  - end_label = params[:closed].present? ? 'und' : 'bis'
+  - start_label = params[:status_preselection] == 'closed' ? 'Abgeschlossen zwischen' : 'Zeiten von'
+  - end_label = params[:status_preselection] == 'closed' ? 'und' : 'bis'
   = direct_filter_date(:start_date, start_label, @period.start_date)
   = direct_filter_date(:end_date, end_label, @period.end_date)
 
   = direct_filter_select(:period_shortcut,
     nil,
-    params[:closed].blank? ? predefined_past_period_options : predefined_past_quarter_period_options,
+    params[:status_preselection].blank? ? predefined_past_period_options : predefined_past_quarter_period_options,
     value: @period.shortcut,
     prompt: 'benutzerdefiniert')
 
@@ -45,7 +46,7 @@
                          class: 'searchable',
                          multiple: true)
 
-  - if params[:closed].blank?
+  - if params[:status_preselection].blank?
     = direct_filter_select(:status_id,
                            'Status',
                            @order_status,

--- a/app/views/order_reports/_filters.html.haml
+++ b/app/views/order_reports/_filters.html.haml
@@ -59,6 +59,12 @@
                          class: 'searchable',
                          multiple: true)
 
+  = direct_filter_select(:without_hours,
+                         'Aufträge ohne Zeitbuchungen',
+                         [IdValue.new('true', 'anzeigen'), IdValue.new('false', 'verbergen')],
+                         class: 'searchable',
+                         value: params[:without_hours] ||= true)
+
   = direct_filter(:target, 'Ziel') do
     - select_tag(:target,
                  options_for_select([['Orange', 'orange'],

--- a/app/views/order_reports/_filters.html.haml
+++ b/app/views/order_reports/_filters.html.haml
@@ -6,7 +6,6 @@
 
 = form_tag(nil, method: :get, class: 'form-inline', role: 'filter', remote: true, data: { spin: true }) do
   = hidden_field_tag :page, 1
-  -# = hidden_field_tag :status_preselection, params[:status_preselection]
   = hidden_field_tag :status_preselection, params[:status_preselection]
 
   - start_label = params[:status_preselection] == 'closed' ? 'Abgeschlossen zwischen' : 'Zeiten von'
@@ -16,8 +15,7 @@
 
   = direct_filter_select(:period_shortcut,
     nil,
-    params[:status_preselection].blank? ? predefined_past_period_options : predefined_past_quarter_period_options,
-    value: @period.shortcut,
+    params[:status_preselection] == 'closed' ? predefined_past_quarter_period_options : predefined_past_period_options,
     prompt: 'benutzerdefiniert')
 
   = direct_filter_select(:department_id,
@@ -46,12 +44,20 @@
                          class: 'searchable',
                          multiple: true)
 
+  
+  - if params[:status_preselection] == 'not_closed'
+    = direct_filter_select(:status_id,
+                            'Status',
+                            @order_status.where(closed: false),
+                            class: 'searchable',
+                            multiple: true)
+
   - if params[:status_preselection].blank?
     = direct_filter_select(:status_id,
-                           'Status',
-                           @order_status,
-                           class: 'searchable',
-                           multiple: true)
+                            'Status',
+                            @order_status,
+                            class: 'searchable',
+                            multiple: true)
 
   = direct_filter_select(:without_hours,
                          'Aufträge ohne Zeitbuchungen',

--- a/app/views/order_reports/_filters.html.haml
+++ b/app/views/order_reports/_filters.html.haml
@@ -53,17 +53,17 @@
                            class: 'searchable',
                            multiple: true)
 
-  = direct_filter_select(:responsible_id,
-                         'Verantwortlich',
-                         @order_responsibles,
-                         class: 'searchable',
-                         multiple: true)
-
   = direct_filter_select(:without_hours,
                          'Aufträge ohne Zeitbuchungen',
                          [IdValue.new('true', 'anzeigen'), IdValue.new('false', 'verbergen')],
                          class: 'searchable',
                          value: params[:without_hours] ||= true)
+
+  = direct_filter_select(:responsible_id,
+                         'Verantwortlich',
+                         @order_responsibles,
+                         class: 'searchable',
+                         multiple: true)
 
   = direct_filter(:target, 'Ziel') do
     - select_tag(:target,

--- a/app/views/order_reports/index.html.haml
+++ b/app/views/order_reports/index.html.haml
@@ -5,10 +5,12 @@
 
 
 %ul.nav.nav-tabs{ role: 'tablist' }
-  %li{ class: ('active' unless params[:closed] == 'true') }
-    = link_to('Laufende', reports_orders_path)
-  %li{ class: ('active' if params[:closed] == 'true') }
-    = link_to('Abgeschlossene', reports_orders_path(closed: true))
+  %li{ class: ('active' if params[:status_preselection].blank?) }
+    = link_to('Alle', reports_orders_path)
+  %li{ class: ('active' if params[:status_preselection] == 'in_progress') }
+    = link_to('Laufende', reports_orders_path(status_preselection: 'in_progress'))
+  %li{ class: ('active' if params[:status_preselection] == 'closed') }
+    = link_to('Abgeschlossene', reports_orders_path(status_preselection: 'closed'))
 
 - @title ||= 'Auftrags-Controlling'
 

--- a/app/views/order_reports/index.html.haml
+++ b/app/views/order_reports/index.html.haml
@@ -6,11 +6,11 @@
 
 %ul.nav.nav-tabs{ role: 'tablist' }
   %li{ class: ('active' if params[:status_preselection].blank?) }
-    = link_to('Alle', reports_orders_path, data: { turbolinks: false })
+    = link_to('Alle', reports_orders_path)
   %li{ class: ('active' if params[:status_preselection] == 'not_closed') }
-    = link_to('Laufende', reports_orders_path(status_preselection: 'not_closed'), data: { turbolinks: false })
+    = link_to('Laufende', reports_orders_path(status_preselection: 'not_closed'))
   %li{ class: ('active' if params[:status_preselection] == 'closed') }
-    = link_to('Abgeschlossene', reports_orders_path(status_preselection: 'closed'), data: { turbolinks: false })
+    = link_to('Abgeschlossene', reports_orders_path(status_preselection: 'closed'))
 
 - @title ||= 'Auftrags-Controlling'
 

--- a/app/views/order_reports/index.html.haml
+++ b/app/views/order_reports/index.html.haml
@@ -7,8 +7,8 @@
 %ul.nav.nav-tabs{ role: 'tablist' }
   %li{ class: ('active' if params[:status_preselection].blank?) }
     = link_to('Alle', reports_orders_path, data: { turbolinks: false })
-  %li{ class: ('active' if params[:status_preselection] == 'in_progress') }
-    = link_to('Laufende', reports_orders_path(status_preselection: 'in_progress'), data: { turbolinks: false })
+  %li{ class: ('active' if params[:status_preselection] == 'not_closed') }
+    = link_to('Laufende', reports_orders_path(status_preselection: 'not_closed'), data: { turbolinks: false })
   %li{ class: ('active' if params[:status_preselection] == 'closed') }
     = link_to('Abgeschlossene', reports_orders_path(status_preselection: 'closed'), data: { turbolinks: false })
 

--- a/app/views/order_reports/index.html.haml
+++ b/app/views/order_reports/index.html.haml
@@ -6,11 +6,11 @@
 
 %ul.nav.nav-tabs{ role: 'tablist' }
   %li{ class: ('active' if params[:status_preselection].blank?) }
-    = link_to('Alle', reports_orders_path)
+    = link_to('Alle', reports_orders_path, data: { turbolinks: false })
   %li{ class: ('active' if params[:status_preselection] == 'in_progress') }
-    = link_to('Laufende', reports_orders_path(status_preselection: 'in_progress'))
+    = link_to('Laufende', reports_orders_path(status_preselection: 'in_progress'), data: { turbolinks: false })
   %li{ class: ('active' if params[:status_preselection] == 'closed') }
-    = link_to('Abgeschlossene', reports_orders_path(status_preselection: 'closed'))
+    = link_to('Abgeschlossene', reports_orders_path(status_preselection: 'closed'), data: { turbolinks: false })
 
 - @title ||= 'Auftrags-Controlling'
 

--- a/app/views/order_reports/index.html.haml
+++ b/app/views/order_reports/index.html.haml
@@ -8,7 +8,7 @@
   %li{ class: ('active' if params[:status_preselection].blank?) }
     = link_to('Alle', reports_orders_path, data: { turbolinks: false })
   %li{ class: ('active' if params[:status_preselection] == 'not_closed') }
-    = link_to('Laufende', reports_orders_path(status_preselection: 'not_closed', department_id: @user.department_id, period_shortcut: '0m', status_id: @order_status.where(closed: false).where(default:true).pluck(:id).first), data: { turbolinks: false })
+    = link_to('Laufende', reports_orders_path(status_preselection: 'not_closed'), data: { turbolinks: false })
   %li{ class: ('active' if params[:status_preselection] == 'closed') }
     = link_to('Abgeschlossene', reports_orders_path(status_preselection: 'closed'), data: { turbolinks: false })
 

--- a/app/views/order_reports/index.html.haml
+++ b/app/views/order_reports/index.html.haml
@@ -8,7 +8,7 @@
   %li{ class: ('active' if params[:status_preselection].blank?) }
     = link_to('Alle', reports_orders_path, data: { turbolinks: false })
   %li{ class: ('active' if params[:status_preselection] == 'not_closed') }
-    = link_to('Laufende', reports_orders_path(status_preselection: 'not_closed'), data: { turbolinks: false })
+    = link_to('Laufende', reports_orders_path(status_preselection: 'not_closed', department_id: @user.department_id, period_shortcut: '0m', status_id: @order_status.where(closed: false).where(default:true).pluck(:id).first), data: { turbolinks: false })
   %li{ class: ('active' if params[:status_preselection] == 'closed') }
     = link_to('Abgeschlossene', reports_orders_path(status_preselection: 'closed'), data: { turbolinks: false })
 


### PR DESCRIPTION
At the moment, in the 'Laufende' Tab, as it was before, all orders with 0 hours booked onto them are filtered out. I left this as it is (now for the tab 'Alle'), but I don't understand 100% why this was implemented this way. I could also remove it, if this is desired.