### PR TITLE
Show remaining budget upon creation of new worktime (51298)

### DIFF
--- a/app/assets/javascripts/modules/autocomplete.js.coffee
+++ b/app/assets/javascripts/modules/autocomplete.js.coffee
@@ -28,21 +28,6 @@ class app.Autocomplete
     ['name', 'path_shortnames', 'path_names']
 
   onInitialize: (input) ->
-    ->
-      selectize = @
-      if selectize.items.length == 1
-        value = selectize.getValue()
-        selectize.removeOption(value)
-        
-        $.ajax(
-            url: Autocomplete.prototype.buildUrl(input, "id", value),
-            type: 'GET',
-            success: (res) ->
-              option = res[0]
-              selectize.addOption(option);
-              selectize.setValue(option.id, true)
-              selectize.trigger('item_add', option.id, selectize.getItem(option.id)) # Manually trigger event
-          )
       
   onItemAdd: ->
 

--- a/app/assets/javascripts/modules/autocomplete.js.coffee
+++ b/app/assets/javascripts/modules/autocomplete.js.coffee
@@ -20,12 +20,15 @@ class app.Autocomplete
       },
       load: @loadOptions(input),
       onItemAdd: @onItemAdd
+      onItemRemove: @onItemRemove
     )
 
   searchFields: ->
     ['name', 'path_shortnames', 'path_names']
 
   onItemAdd: ->
+
+  onItemRemove: ->
 
   renderOption: (item, escape) ->
     "<div class='selectize-option'>" +

--- a/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
+++ b/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
@@ -16,7 +16,7 @@ class app.WorkItemAutocomplete extends app.Autocomplete
       return 'orange'
     'green'
 
-  onItemAdd: (value, item) ->
+  onItemAdd: (value, item)  =>
     billable = item.attr('data-billable') == 'true'
     meal_compensation = item.attr('data-meal_compensation') == 'true'
     $('#ordertime_billable').prop('checked', billable);
@@ -25,6 +25,8 @@ class app.WorkItemAutocomplete extends app.Autocomplete
     # renderes a progress bar depending on how much of the budget is already used
     offered_hours = item.attr('data-offered_hours')
     done_hours = parseFloat(item.attr('data-done_hours')).toFixed(2)
+    $('#live_bar_success').removeClass( "bg-green bg-orange bg-red" ).addClass("bg-" + @picked_color(offered_hours, done_hours));
+
     if offered_hours? and offered_hours != 'null'  
       offered_hours = parseFloat(offered_hours).toFixed(2)  
       percentage = parseFloat(done_hours * 100 / offered_hours).toFixed(2)  
@@ -32,14 +34,14 @@ class app.WorkItemAutocomplete extends app.Autocomplete
       offered_hours = '∞'
       percentage = 0
     
-    $('.live_budget_bar').show();
-    $('#live_bar_success').width(Math.min(percentage,100) + '%');
     $('.live_budget_bar').attr('data-original-title', "#{ done_hours } h / #{ offered_hours } h (#{ percentage }%)");
+    $('.live_budget_bar').css("visibility", "visible");
+    $('#live_bar_success').width(Math.min(percentage,100) + '%');
       
   onItemRemove: (value, item) ->
     # Removes the progress bar if no position is set
     $('#live_bar_success').width(0 + '%');
-    $('.live_budget_bar').hide();
+    $('.live_budget_bar').css("visibility", "hidden");
 
   renderOption: (item, escape) ->
     "<div class='selectize-option'>" +
@@ -56,5 +58,5 @@ class app.WorkItemAutocomplete extends app.Autocomplete
 $(document).on('turbolinks:load', ->
   $('[data-autocomplete=work_item]').each((i, element) -> new app.WorkItemAutocomplete().bind(element))
   # hide the progress bar depicting the usage of the budget upon initialization of the site
-  $('.live_budget_bar').hide();
+  $('.live_budget_bar').css("visibility", "hidden");
 )

--- a/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
+++ b/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
@@ -7,24 +7,52 @@
 app = window.App ||= {}
 
 class app.WorkItemAutocomplete extends app.Autocomplete
+  picked_color: (offered_hrs, done_hrs) ->
+    if offered_hrs == null
+      return 'green'
+    if done_hrs / offered_hrs >= 1
+        return 'red'
+    if done_hrs / offered_hrs >= 0.8
+        return 'orange'
+    'green'
 
   onItemAdd: (value, item) ->
+    console.log(item)
     billable = item.attr('data-billable') == 'true'
     meal_compensation = item.attr('data-meal_compensation') == 'true'
     $('#ordertime_billable').prop('checked', billable);
     $('#ordertime_meal_compensation').prop('checked', meal_compensation);
 
+    offered_hours = item.attr('data-offered_hours')
+    done_hours = item.attr('data-done_hours')
+    percentage = done_hours * 100 / offered_hours
+      
+    console.log(done_hours + "/" + offered_hours)
+    $('.live_budget_bar').show();
+    $('#live_bar_success').width(Math.min(percentage,100) + '%');
+    $('.live_budget_bar').attr('data-original-title', "#{ parseFloat(done_hours).toFixed(1) } h / #{ parseFloat(offered_hours).toFixed(1) } h (#{ percentage.toFixed(2) }%)");
+      
+    
+
+  onItemRemove: (value, item) ->
+    $('#live_bar_success').width(0 + '%');
+    $('.live_budget_bar').hide();
+
   renderOption: (item, escape) ->
     "<div class='selectize-option'>" +
+      "<div class='#{@picked_color(item.offered_hours, item.done_hours)} icon-disk'></div>" +
       "<div class='shortname'>#{ escape(item.path_shortnames) }</div>" +
       "<div class='name'>#{ escape(@limitText(item.name, 70)) }</div>" +
       "<div class='description'>#{ escape(@limitText(item.description || '', 120)) }</div>" +
       "</div>"
+    
+  # TODO: update progress bar on update
 
   renderItem: (item, escape) ->
-    "<div data-billable=#{ item.billable } data-meal_compensation=#{ item.meal_compensation }>" +
+    "<div data-billable=#{ item.billable } data-meal_compensation=#{ item.meal_compensation } data-offered_hours=#{ item.offered_hours } data-done_hours=#{ item.done_hours }>" +
     "#{ escape(item.path_shortnames) }: #{ escape(item.name) }</div>"
 
 $(document).on('turbolinks:load', ->
   $('[data-autocomplete=work_item]').each((i, element) -> new app.WorkItemAutocomplete().bind(element))
+  $('.live_budget_bar').hide();
 )

--- a/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
+++ b/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
@@ -20,7 +20,7 @@ class app.WorkItemAutocomplete extends app.Autocomplete
     # renderes a progress bar depending on how much of the budget is already used
     offered_hours = item.attr('data-offered_hours')
     done_hours = parseFloat(item.attr('data-done_hours')).toFixed(2)
-    $('#live_bar_success').removeClass( "bg-green bg-orange bg-red" ).addClass("bg-" + @picked_color(offered_hours, done_hours));
+    $('#live-bar-success').removeClass( "bg-green bg-orange bg-red" ).addClass("bg-" + @picked_color(offered_hours, done_hours));
 
     # handle the case where the budget is not set (offered_hours == 'null')
     # CAREFUL: if not set in the db, due to the json serializer, offered_hours will be 'null' (string). 
@@ -33,25 +33,24 @@ class app.WorkItemAutocomplete extends app.Autocomplete
       percentage = 0
 
     # set tooltip
-    $('.live_budget_bar').attr('data-original-title', "#{ done_hours } h / #{ offered_hours } h (#{ percentage }%)");
+    $('.live-budget-bar').attr('data-original-title', "#{ done_hours } h / #{ offered_hours } h (#{ percentage }%)");
     # show progress bar
-    $('.live_budget_bar').css("visibility", "visible");
+    $('.live-budget-bar').css("visibility", "visible");
     # set length of filled part of progress bar
-    $('#live_bar_success').width(Math.min(percentage,100) + '%');
+    $('#live-bar-success').width(Math.min(percentage,100) + '%');
 
   onItemAdd: (value, item)  =>
     billable = item.attr('data-billable') == 'true'
     meal_compensation = item.attr('data-meal_compensation') == 'true'
     $('#ordertime_billable').prop('checked', billable);
     $('#ordertime_meal_compensation').prop('checked', meal_compensation);
-    # sets
     @set_progress_bar(item)
     
       
   onItemRemove: (value, item) ->
     # Removes the progress bar if no position is selected
-    $('#live_bar_success').width(0 + '%');
-    $('.live_budget_bar').css("visibility", "hidden");
+    $('#live-bar-success').width(0 + '%');
+    $('.live-budget-bar').css("visibility", "hidden");
 
   renderOption: (item, escape) ->
     "<div class='selectize-option'>" +
@@ -68,5 +67,5 @@ class app.WorkItemAutocomplete extends app.Autocomplete
 $(document).on('turbolinks:load', ->
   $('[data-autocomplete=work_item]').each((i, element) -> new app.WorkItemAutocomplete().bind(element))
   # hide the progress bar depicting the usage of the budget upon initialization of the site
-  $('.live_budget_bar').css("visibility", "hidden");
+  $('.live-budget-bar').css("visibility", "hidden");
 )

--- a/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
+++ b/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
@@ -11,30 +11,33 @@ class app.WorkItemAutocomplete extends app.Autocomplete
     if offered_hrs == null
       return 'green'
     if done_hrs / offered_hrs >= 1
-        return 'red'
+      return 'red'
     if done_hrs / offered_hrs >= 0.8
-        return 'orange'
+      return 'orange'
     'green'
 
   onItemAdd: (value, item) ->
-    console.log(item)
     billable = item.attr('data-billable') == 'true'
     meal_compensation = item.attr('data-meal_compensation') == 'true'
     $('#ordertime_billable').prop('checked', billable);
     $('#ordertime_meal_compensation').prop('checked', meal_compensation);
 
+    # renderes a progress bar depending on how much of the budget is already used
     offered_hours = item.attr('data-offered_hours')
-    done_hours = item.attr('data-done_hours')
-    percentage = done_hours * 100 / offered_hours
-      
-    console.log(done_hours + "/" + offered_hours)
+    done_hours = parseFloat(item.attr('data-done_hours')).toFixed(2)
+    if offered_hours? and offered_hours != 'null'  
+      offered_hours = parseFloat(offered_hours).toFixed(2)  
+      percentage = parseFloat(done_hours * 100 / offered_hours).toFixed(2)  
+    else
+      offered_hours = '∞'
+      percentage = 0
+    
     $('.live_budget_bar').show();
     $('#live_bar_success').width(Math.min(percentage,100) + '%');
-    $('.live_budget_bar').attr('data-original-title', "#{ parseFloat(done_hours).toFixed(1) } h / #{ parseFloat(offered_hours).toFixed(1) } h (#{ percentage.toFixed(2) }%)");
+    $('.live_budget_bar').attr('data-original-title', "#{ done_hours } h / #{ offered_hours } h (#{ percentage }%)");
       
-    
-
   onItemRemove: (value, item) ->
+    # Removes the progress bar if no position is set
     $('#live_bar_success').width(0 + '%');
     $('.live_budget_bar').hide();
 
@@ -46,13 +49,12 @@ class app.WorkItemAutocomplete extends app.Autocomplete
       "<div class='description'>#{ escape(@limitText(item.description || '', 120)) }</div>" +
       "</div>"
     
-  # TODO: update progress bar on update
-
   renderItem: (item, escape) ->
     "<div data-billable=#{ item.billable } data-meal_compensation=#{ item.meal_compensation } data-offered_hours=#{ item.offered_hours } data-done_hours=#{ item.done_hours }>" +
     "#{ escape(item.path_shortnames) }: #{ escape(item.name) }</div>"
 
 $(document).on('turbolinks:load', ->
   $('[data-autocomplete=work_item]').each((i, element) -> new app.WorkItemAutocomplete().bind(element))
+  # hide the progress bar depicting the usage of the budget upon initialization of the site
   $('.live_budget_bar').hide();
 )

--- a/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
+++ b/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
@@ -37,6 +37,23 @@ class app.WorkItemAutocomplete extends app.Autocomplete
     # set length of filled part of progress bar
     $('#live-bar-success').width(Math.min(percentage,100) + '%');
 
+  onInitialize: (input) ->
+    ->
+      selectize = $(input).data('selectize')
+      if selectize.items.length == 1
+        value = selectize.getValue()
+        selectize.removeOption(value)
+        
+        $.ajax(
+            url: app.Autocomplete.prototype.buildUrl(input, "id", value),
+            type: 'GET',
+            success: (res) ->
+              option = res[0]
+              selectize.addOption(option);
+              selectize.setValue(option.id, true)
+              selectize.trigger('item_add', option.id, selectize.getItem(option.id)) # Manually trigger event
+          )
+
   onItemAdd: (value, item)  =>
     billable = item.attr('data-billable') == 'true'
     meal_compensation = item.attr('data-meal_compensation') == 'true'

--- a/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
+++ b/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
@@ -34,8 +34,6 @@ class app.WorkItemAutocomplete extends app.Autocomplete
 
     # set tooltip
     $('.live-budget-bar').attr('data-original-title', "#{ done_hours } h / #{ offered_hours } h (#{ percentage }%)");
-    # show progress bar
-    $('.live-budget-bar').css("visibility", "visible");
     # set length of filled part of progress bar
     $('#live-bar-success').width(Math.min(percentage,100) + '%');
 
@@ -47,11 +45,11 @@ class app.WorkItemAutocomplete extends app.Autocomplete
     @set_progress_bar(item)
     
       
-  onItemRemove: (value, item) ->
+  onItemRemove: (value) ->
     # Removes the progress bar if no position is selected
     $('#live-bar-success').width(0 + '%');
-    $('.live-budget-bar').css("visibility", "hidden");
-
+    $('.live-budget-bar').attr('data-original-title', "Wähle eine Buchungsposition aus");
+  
   renderOption: (item, escape) ->
     "<div class='selectize-option'>" +
       "<div class='#{@picked_color(item.offered_hours, item.done_hours)} icon-disk'></div>" +
@@ -66,6 +64,4 @@ class app.WorkItemAutocomplete extends app.Autocomplete
 
 $(document).on('turbolinks:load', ->
   $('[data-autocomplete=work_item]').each((i, element) -> new app.WorkItemAutocomplete().bind(element))
-  # hide the progress bar depicting the usage of the budget upon initialization of the site
-  $('.live-budget-bar').css("visibility", "hidden");
 )

--- a/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
+++ b/app/assets/javascripts/modules/work_item_autocomplete.js.coffee
@@ -16,30 +16,40 @@ class app.WorkItemAutocomplete extends app.Autocomplete
       return 'orange'
     'green'
 
-  onItemAdd: (value, item)  =>
-    billable = item.attr('data-billable') == 'true'
-    meal_compensation = item.attr('data-meal_compensation') == 'true'
-    $('#ordertime_billable').prop('checked', billable);
-    $('#ordertime_meal_compensation').prop('checked', meal_compensation);
-
+  set_progress_bar: (item) =>
     # renderes a progress bar depending on how much of the budget is already used
     offered_hours = item.attr('data-offered_hours')
     done_hours = parseFloat(item.attr('data-done_hours')).toFixed(2)
     $('#live_bar_success').removeClass( "bg-green bg-orange bg-red" ).addClass("bg-" + @picked_color(offered_hours, done_hours));
 
+    # handle the case where the budget is not set (offered_hours == 'null')
+    # CAREFUL: if not set in the db, due to the json serializer, offered_hours will be 'null' (string). 
+    #   Nevertheless, we also check for null in case this changes in the future
     if offered_hours? and offered_hours != 'null'  
       offered_hours = parseFloat(offered_hours).toFixed(2)  
       percentage = parseFloat(done_hours * 100 / offered_hours).toFixed(2)  
     else
       offered_hours = '∞'
       percentage = 0
-    
+
+    # set tooltip
     $('.live_budget_bar').attr('data-original-title', "#{ done_hours } h / #{ offered_hours } h (#{ percentage }%)");
+    # show progress bar
     $('.live_budget_bar').css("visibility", "visible");
+    # set length of filled part of progress bar
     $('#live_bar_success').width(Math.min(percentage,100) + '%');
+
+  onItemAdd: (value, item)  =>
+    billable = item.attr('data-billable') == 'true'
+    meal_compensation = item.attr('data-meal_compensation') == 'true'
+    $('#ordertime_billable').prop('checked', billable);
+    $('#ordertime_meal_compensation').prop('checked', meal_compensation);
+    # sets
+    @set_progress_bar(item)
+    
       
   onItemRemove: (value, item) ->
-    # Removes the progress bar if no position is set
+    # Removes the progress bar if no position is selected
     $('#live_bar_success').width(0 + '%');
     $('.live_budget_bar').css("visibility", "hidden");
 

--- a/app/assets/stylesheets/components/_progress.scss
+++ b/app/assets/stylesheets/components/_progress.scss
@@ -1,3 +1,13 @@
 .progress {
   display: block;
 }
+
+.live_budget_bar {
+  .progress {
+    height: 7px;
+    margin-bottom: 0;
+    // background-color: white;
+    // box-shadow:none;
+  }
+}
+

--- a/app/assets/stylesheets/components/_progress.scss
+++ b/app/assets/stylesheets/components/_progress.scss
@@ -2,12 +2,10 @@
   display: block;
 }
 
-.live_budget_bar {
+.live-budget-bar {
   .progress {
     height: 7px;
     margin-bottom: 0;
-    // background-color: white;
-    // box-shadow:none;
   }
 }
 

--- a/app/assets/stylesheets/components/_selectize.scss
+++ b/app/assets/stylesheets/components/_selectize.scss
@@ -37,6 +37,13 @@
   .description {
     font-size: 11px;
   }
+
+  .icon-disk {
+    display: inline-block;
+    content: "\62";
+    margin-right: 5px;
+    font-size: smaller;
+  }
 }
 
 /* Fix a bug, where the input would be reduced to 4px when empty */

--- a/app/assets/stylesheets/puzzletime.scss
+++ b/app/assets/stylesheets/puzzletime.scss
@@ -197,16 +197,32 @@ a[data-toggle] {
   color: $brand-danger;
 }
 
+.bg-red {
+  background-color: $brand-danger;
+}
+
 .green {
   color: $brand-success;
+}
+
+.bg-green {
+  background-color: $brand-success;
 }
 
 .orange {
   color: $brand-warning;
 }
 
+.bg-orange {
+  background-color: $brand-warning;
+}
+
 .yellow {
   color: $brand-info;
+}
+
+.bg-yellow {
+  background-color: $brand-info;
 }
 
 .tooltip p {

--- a/app/controllers/work_items_controller.rb
+++ b/app/controllers/work_items_controller.rb
@@ -10,15 +10,22 @@ class WorkItemsController < ManageController
   self.search_columns = %i[path_shortnames path_names description]
 
   def search
-    params[:q] ||= params[:term]
     respond_to do |format|
       format.json do
-        @work_items = WorkItem.recordable
-                              .list
-                              .where(search_conditions)
-                              .joins(:accounting_post)
-                              .includes(:accounting_post)
-                              .limit(20)
+        @work_items = if params[:id].present?
+                        WorkItem.recordable
+                                .joins(:accounting_post)
+                                .includes(:accounting_post)
+                                .where(id: params[:id])
+                      else
+                        params[:q] ||= params[:term]
+                        WorkItem.recordable
+                                .list
+                                .where(search_conditions)
+                                .joins(:accounting_post)
+                                .includes(:accounting_post)
+                                .limit(20)
+                      end
       end
     end
   end

--- a/app/views/ordertimes/_form.html.haml
+++ b/app/views/ordertimes/_form.html.haml
@@ -26,9 +26,9 @@
                   required: true,
                   data: { autocomplete: 'work_item',
                           url: search_work_items_path })
-      %span{ title: "", data: { toggle: "tooltip", original_title: "Budgetnutzung" }, class: "live_budget_bar"}
+      %span{ title: "", data: { toggle: "tooltip", original_title: "Budgetnutzung" }, class: "live-budget-bar"}
         %a.progress
-          %div#live_bar_success.progress-bar
+          %div#live-bar-success.progress-bar
 
   = f.labeled_input_field(:ticket, span: 2)
   = f.labeled_text_area(:description)

--- a/app/views/ordertimes/_form.html.haml
+++ b/app/views/ordertimes/_form.html.haml
@@ -26,7 +26,7 @@
                   required: true,
                   data: { autocomplete: 'work_item',
                           url: search_work_items_path })
-      %span{ title: "", data: { toggle: "tooltip", original_title: "Budgetnutzung" }, class: "live-budget-bar"}
+      %span{ title: "", data: { toggle: "tooltip", original_title: "Wähle eine Buchungsposition aus" }, class: "live-budget-bar"}
         %a.progress
           %div#live-bar-success.progress-bar
 

--- a/app/views/ordertimes/_form.html.haml
+++ b/app/views/ordertimes/_form.html.haml
@@ -17,14 +17,19 @@
                                           url: url_for(action: 'existing'),
                                           dynamic_params: 'ordertime[work_date]' })
   = f.labeled(:account_id) do
-    = select_tag('ordertime[account_id]',
-                 work_item_option(@worktime.account),
-                 placeholder: 'Suchen...',
-                 autocomplete: 'off',
-                 class: entry.new_record? ? 'initial-focus' : '',
-                 required: true,
-                 data: { autocomplete: 'work_item',
-                         url: search_work_items_path })
+    %div
+      = select_tag('ordertime[account_id]',
+                  work_item_option(@worktime.account),
+                  placeholder: 'Suchen...',
+                  autocomplete: 'off',
+                  class: entry.new_record? ? 'initial-focus' : '',
+                  required: true,
+                  data: { autocomplete: 'work_item',
+                          url: search_work_items_path })
+      %span{ title: "", data: { toggle: "tooltip", original_title: "Budgetnutzung" }, class: "live_budget_bar"}
+        %a.progress
+          %div#live_bar_success.progress-bar
+
   = f.labeled_input_field(:ticket, span: 2)
   = f.labeled_text_area(:description)
   = f.labeled_date_field(:work_date,

--- a/app/views/work_items/search.json.jbuilder
+++ b/app/views/work_items/search.json.jbuilder
@@ -8,4 +8,9 @@ json.array! @work_items do |item|
   json.path_names item.path_names
   json.billable item.accounting_post&.billable
   json.meal_compensation item.accounting_post&.meal_compensation
+  json.work_item_id item.accounting_post&.work_item_id
+  json.offered_hours AccountingPost.where(work_item_id: item.accounting_post&.work_item_id).pick(:offered_hours)
+  json.done_hours AccountingPost.where(work_item_id: item.accounting_post.work_item_id).first.worktimes.sum(:hours)
+  # TODO: .where(billable: true) beibehalten?
+  # json.done_hours AccountingPost.where(work_item_id: item.accounting_post.work_item_id).first.worktimes.where(billable: true).sum(:hours)
 end

--- a/app/views/work_items/search.json.jbuilder
+++ b/app/views/work_items/search.json.jbuilder
@@ -9,8 +9,7 @@ json.array! @work_items do |item|
   json.billable item.accounting_post&.billable
   json.meal_compensation item.accounting_post&.meal_compensation
   json.work_item_id item.accounting_post&.work_item_id
-  json.offered_hours AccountingPost.where(work_item_id: item.accounting_post&.work_item_id).pick(:offered_hours)
-  json.done_hours AccountingPost.where(work_item_id: item.accounting_post.work_item_id).first.worktimes.sum(:hours)
-  # TODO: .where(billable: true) beibehalten?
-  # json.done_hours AccountingPost.where(work_item_id: item.accounting_post.work_item_id).first.worktimes.where(billable: true).sum(:hours)
+  accounting_post = AccountingPost.where(work_item_id: item.accounting_post&.work_item_id)
+  json.offered_hours accounting_post&.pick(:offered_hours)
+  json.done_hours accounting_post&.first&.worktimes&.sum(:hours)
 end

--- a/test/integration/create_ordertime_test.rb
+++ b/test/integration/create_ordertime_test.rb
@@ -86,7 +86,7 @@ class CreateOrdertimeTest < ActionDispatch::IntegrationTest
 
     percentage = clipped_used_budget_percentage(accounting_posts(:puzzletime))
 
-    assert_equal progressbar_color, should_color(percentage)
+    assert_equal progressbar_color, expected_color(percentage)
   end
 
   test 'going over budget sets the colour of the progressbar to red' do
@@ -100,7 +100,7 @@ class CreateOrdertimeTest < ActionDispatch::IntegrationTest
 
     percentage = clipped_used_budget_percentage(accounting_posts(:puzzletime))
 
-    assert_equal progressbar_color, should_color(percentage)
+    assert_equal progressbar_color, expected_color(percentage)
   end
 
   def login
@@ -116,7 +116,7 @@ class CreateOrdertimeTest < ActionDispatch::IntegrationTest
     offered_hours.nil? ? 0 : [(worked_hours * 100) / offered_hours, 100].min
   end
 
-  def should_color(percentage)
+  def expected_color(percentage)
     if percentage < 80
       'green'
     else

--- a/test/integration/create_ordertime_test.rb
+++ b/test/integration/create_ordertime_test.rb
@@ -57,8 +57,79 @@ class CreateOrdertimeTest < ActionDispatch::IntegrationTest
     assert_not find('#ordertime_billable').checked?
   end
 
+  test 'selecting a accounting_post sets the progress bar to the correct width, corresponding to the remaining budget' do
+    selectize('ordertime_account_id', 'PuzzleTime', term: 'time')
+
+    percentage = clipped_used_budget_percentage(accounting_posts(:puzzletime))
+
+    assert_operator (percentage - progressbar_width_in_percent).abs, :<, 0.02
+
+    clear_selectize('ordertime_account_id')
+
+    assert_equal 0, progressbar_width_in_percent
+  end
+
+  test 'going over the budget is displayed as 100% width progress bar' do
+    Ordertime.create!(employee: employees(:mark),
+                          work_date: '2015-08-31',
+                          hours: accounting_posts(:puzzletime).offered_hours * 1.5,
+                          work_item: work_items(:puzzletime),
+                          report_type: 'absolute_day')
+
+    selectize('ordertime_account_id', 'PuzzleTime', term: 'time')
+
+    assert_equal 100, progressbar_width_in_percent
+  end
+
+  test 'selecting a accounting_post sets the progress bar to the color green/orange/red, depending on the remaining budget' do
+    selectize('ordertime_account_id', 'PuzzleTime', term: 'time')
+
+    percentage = clipped_used_budget_percentage(accounting_posts(:puzzletime))
+
+    assert_equal progressbar_color, should_color(percentage)
+  end
+
+  test 'going over budget sets the colour of the progressbar to red' do
+    Ordertime.create!(employee: employees(:mark),
+                          work_date: '2015-08-31',
+                          hours: accounting_posts(:puzzletime).offered_hours,
+                          work_item: work_items(:puzzletime),
+                          report_type: 'absolute_day')
+
+    selectize('ordertime_account_id', 'PuzzleTime', term: 'time')
+
+    percentage = clipped_used_budget_percentage(accounting_posts(:puzzletime))
+
+    assert_equal progressbar_color, should_color(percentage)
+  end
+
   def login
     login_as(:pascal)
     visit(new_ordertime_path)
+  end
+
+  #returns the actually used percentage of budget as a float (clipped to 100, if above)
+  def clipped_used_budget_percentage(accounting_post)
+    offered_hours = accounting_post.offered_hours
+    worked_hours = Worktime.where(work_item_id: accounting_post.work_item_id).sum(:hours)
+
+    offered_hours.nil? ? 0 : [(worked_hours * 100) / offered_hours, 100].min
+  end
+
+  def should_color(percentage)
+    if percentage < 80
+      'green'
+    else
+      percentage < 100 ? 'orange' : 'red'
+    end
+  end
+
+  # returns the width of the progressbar in percent as float
+  def progressbar_width_in_percent
+    find('#live-bar-success')['style'][/width: (\d+)%/, 1].to_f
+  end
+
+  def progressbar_color
+    find('#live-bar-success')['class'][/bg-([a-z]+)/, 1]
   end
 end

--- a/test/support/integration_helper.rb
+++ b/test/support/integration_helper.rb
@@ -49,6 +49,12 @@ module IntegrationHelper
     open_selectize(id, options).find('.selectize-option,.option', text: value).trigger('click')
   end
 
+  def clear_selectize(id, options = {})
+    element = find("##{id} + .selectize-control")
+    element.find('.selectize-input').trigger('click') unless options[:no_click]
+    element.find('.selectize-input input').native.send_keys(:backspace)
+  end
+
   def mouse
     page.driver.browser.mouse
   end


### PR DESCRIPTION
When creating a new worktime, show the remaining budget on the chosen position in
- the dropdown menu that is shown when typing in the position field in form of a colored dot
- as a progress bar when a position is selected. The concrete hours are shown as a tooltip.

In both cases, the colors have the following meaning:
- Green: used_hours < 0.8*budget
- Orange: 0.8*budget <= used_hours  < budget
- Red:   budget <= used_hours

