### PR TITLE
correctly show all work_items in the time rapport (64024)

### DIFF
--- a/app/controllers/evaluator_controller.rb
+++ b/app/controllers/evaluator_controller.rb
@@ -137,7 +137,6 @@ class EvaluatorController < ApplicationController
     set_evaluation_details
     @employee = Employee.find(@evaluation.employee_id) if @evaluation.employee_id
     @work_items = [WorkItem.find(@evaluation.account_id)]
-    params[:work_item_ids] ||= @work_items
   end
 
   def set_evaluation_details

--- a/app/controllers/order_services_controller.rb
+++ b/app/controllers/order_services_controller.rb
@@ -75,8 +75,8 @@ class OrderServicesController < ApplicationController
   end
 
   def prepare_report_header
-    params[:work_item_ids] ||= [params[:work_item_id].presence || order.work_item_id]
-    @work_items = WorkItem.find(params[:work_item_ids])
+    work_item_ids = [params[:work_item_id].presence || order.work_item_id]
+    @work_items = WorkItem.find(work_item_ids)
     @employee = Employee.find(params[:employee_id]) if params[:employee_id].present?
     set_period_with_invoice
   end

--- a/app/controllers/order_services_controller.rb
+++ b/app/controllers/order_services_controller.rb
@@ -75,8 +75,8 @@ class OrderServicesController < ApplicationController
   end
 
   def prepare_report_header
-    work_item_ids = [params[:work_item_id].presence || order.work_item_id]
-    @work_items = WorkItem.find(work_item_ids)
+    params[:work_item_ids] ||= [params[:work_item_id].presence || order.work_item_id]
+    @work_items = WorkItem.find(params[:work_item_ids])
     @employee = Employee.find(params[:employee_id]) if params[:employee_id].present?
     set_period_with_invoice
   end

--- a/app/controllers/order_services_controller.rb
+++ b/app/controllers/order_services_controller.rb
@@ -80,6 +80,7 @@ class OrderServicesController < ApplicationController
     work_item_ids ||= order.accounting_posts.collect(&:work_item_id)
     work_item_ids = Array.wrap(work_item_ids)
     @work_items = WorkItem.find(work_item_ids)
+    @order = order
     @employee = Employee.find(params[:employee_id]) if params[:employee_id].present?
     set_period_with_invoice
   end

--- a/app/controllers/order_services_controller.rb
+++ b/app/controllers/order_services_controller.rb
@@ -75,9 +75,11 @@ class OrderServicesController < ApplicationController
   end
 
   def prepare_report_header
-    params[:work_item_ids] ||= params[:work_item_id].present? ? [params[:work_item_id]] : order.accounting_posts.collect(&:work_item_id)
-    Rails.logger.info("#AAA: #{params[:work_item_ids].inspect}")
-    @work_items = WorkItem.find(params[:work_item_ids])
+    params[:work_item_ids] = params[:work_item_id].presence
+    work_item_ids ||= params[:work_item_id].presence
+    work_item_ids ||= order.accounting_posts.collect(&:work_item_id)
+    work_item_ids = Array.wrap(work_item_ids)
+    @work_items = work_item_ids
     @employee = Employee.find(params[:employee_id]) if params[:employee_id].present?
     set_period_with_invoice
   end

--- a/app/controllers/order_services_controller.rb
+++ b/app/controllers/order_services_controller.rb
@@ -75,11 +75,11 @@ class OrderServicesController < ApplicationController
   end
 
   def prepare_report_header
-    params[:work_item_ids] = params[:work_item_id].presence
+    work_item_ids = params[:work_item_ids].presence
     work_item_ids ||= params[:work_item_id].presence
     work_item_ids ||= order.accounting_posts.collect(&:work_item_id)
     work_item_ids = Array.wrap(work_item_ids)
-    @work_items = work_item_ids
+    @work_items = WorkItem.find(work_item_ids)
     @employee = Employee.find(params[:employee_id]) if params[:employee_id].present?
     set_period_with_invoice
   end

--- a/app/controllers/order_services_controller.rb
+++ b/app/controllers/order_services_controller.rb
@@ -75,7 +75,8 @@ class OrderServicesController < ApplicationController
   end
 
   def prepare_report_header
-    params[:work_item_ids] ||= [params[:work_item_id].presence || order.work_item_id]
+    params[:work_item_ids] ||= params[:work_item_id].present? ? [params[:work_item_id]] : order.accounting_posts.collect(&:work_item_id)
+    Rails.logger.info("#AAA: #{params[:work_item_ids].inspect}")
     @work_items = WorkItem.find(params[:work_item_ids])
     @employee = Employee.find(params[:employee_id]) if params[:employee_id].present?
     set_period_with_invoice

--- a/app/views/worktimes_report/_report_config.html.haml
+++ b/app/views/worktimes_report/_report_config.html.haml
@@ -11,8 +11,9 @@
 = form_tag({ action: 'report' }, method: 'get') do
   - %w(evaluation start_date end_date period_shortcut category_id division_id employee_id ticket invoice_id billable).each do |p|
     = hidden_field_tag p, params[p] if params[p]
-  - params['work_item_ids'].each do |v|
-    = hidden_field_tag 'work_item_ids[]', v
+  - if params['work_item_ids'].present?
+    - params['work_item_ids'].each do |v|
+      = hidden_field_tag 'work_item_ids[]', v
 
   - if billable_option
     .checkbox

--- a/app/views/worktimes_report/_report_config.html.haml
+++ b/app/views/worktimes_report/_report_config.html.haml
@@ -11,8 +11,8 @@
 = form_tag({ action: 'report' }, method: 'get') do
   - %w(evaluation start_date end_date period_shortcut category_id division_id employee_id ticket invoice_id billable).each do |p|
     = hidden_field_tag p, params[p] if params[p]
-  - params['work_item_ids'].each do |v|
-    = hidden_field_tag 'work_item_ids[]', v
+  - @work_items.each do |v|
+    = hidden_field_tag 'work_item_ids[]', v.id
 
   - if billable_option
     .checkbox

--- a/app/views/worktimes_report/_report_config.html.haml
+++ b/app/views/worktimes_report/_report_config.html.haml
@@ -11,9 +11,8 @@
 = form_tag({ action: 'report' }, method: 'get') do
   - %w(evaluation start_date end_date period_shortcut category_id division_id employee_id ticket invoice_id billable).each do |p|
     = hidden_field_tag p, params[p] if params[p]
-  - if params['work_item_ids'].present?
-    - params['work_item_ids'].each do |v|
-      = hidden_field_tag 'work_item_ids[]', v
+  - params['work_item_ids'].each do |v|
+    = hidden_field_tag 'work_item_ids[]', v
 
   - if billable_option
     .checkbox

--- a/app/views/worktimes_report/_report_header.html.haml
+++ b/app/views/worktimes_report/_report_header.html.haml
@@ -12,9 +12,16 @@
   %tr
     %td Auftrag
     %td
-      - @work_items.map do |w|
-        %b= w.label_ancestry
+      - if @order.present? # in the case of order_services
+        %b= @order
         %br
+        - @work_items.map do |w|
+          = w.name
+          %br
+      - else  # in the case of evaluator
+        - @work_items.map do |w|
+          = w.label_ancestry
+          %br
   - if @employee
     %tr
       %td Member

--- a/app/views/worktimes_report/_report_header.html.haml
+++ b/app/views/worktimes_report/_report_header.html.haml
@@ -12,12 +12,9 @@
   %tr
     %td Auftrag
     %td
-      - if @order.present?
-        %b= @order
-      - else
-        - @work_items.map do |w|
-          %b= w.label_ancestry
-          %br
+      - @work_items.map do |w|
+        %b= w.label_ancestry
+        %br
   - if @employee
     %tr
       %td Member

--- a/app/views/worktimes_report/_report_header.html.haml
+++ b/app/views/worktimes_report/_report_header.html.haml
@@ -12,7 +12,12 @@
   %tr
     %td Auftrag
     %td
-      %b= @work_items[0].label_ancestry
+      - if @order.present?
+        %b= @order
+      - else
+        - @work_items.map do |w|
+          %b= w.label_ancestry
+          %br
   - if @employee
     %tr
       %td Member


### PR DESCRIPTION
fix a bug, where only the first work_item is shown in the time rapport