### PR TITLE
implement splitting of numbers with apostrophe and add hours to tooltip (63923)

### DIFF
--- a/app/assets/javascripts/order_controlling.js.coffee
+++ b/app/assets/javascripts/order_controlling.js.coffee
@@ -7,7 +7,7 @@
 app = window.App ||= {}
 
 
-app.initOrderControllingChart = (labels, datasets, budget, currency, currentLabel) ->
+app.initOrderControllingChart = (labels, datasets, budget, budget_hours, currency, currentLabel) ->
   canvas = document.getElementById('order_controlling_chart')
   ctx = canvas.getContext('2d')
 
@@ -20,7 +20,10 @@ app.initOrderControllingChart = (labels, datasets, budget, currency, currentLabe
   gridColor = 'rgba(0,0,0,0.1)'
   gridLightColor = 'rgba(0,0,0,0.02)'
 
-  formatCurrency = (value) -> Number(value).toLocaleString() + ' ' + currency
+  formatCurrency = (value) ->
+    new Intl.NumberFormat('de-CH', {
+      style: 'decimal'
+    }).format(value) + ' ' + currency
 
   chart = new Chart(ctx, {
     type: 'bar',
@@ -54,13 +57,19 @@ app.initOrderControllingChart = (labels, datasets, budget, currency, currentLabe
           boxWidth: Chart.defaults.font.size
         }
       },
-      tooltips: {
-        callbacks: {
-          label: (item, data) ->
-            data.datasets[item.datasetIndex].label + ': ' + formatCurrency(item.yLabel)
-        }
-      },
       plugins: {
+        tooltip: {
+          callbacks: {
+            label: (tooltipItem) ->
+              hours = tooltipItem.dataset.tooltipData[tooltipItem.dataIndex];
+              datasetLabel = tooltipItem.dataset.label
+              value = formatCurrency(tooltipItem.raw)
+              [
+                "#{datasetLabel}:"
+                "#{value} (#{hours}h)"
+              ]
+            }
+        },
         annotation: {
           annotations: [{
             type: 'line',
@@ -90,7 +99,7 @@ app.initOrderControllingChart = (labels, datasets, budget, currency, currentLabe
             borderWidth: 2,
             label: {
               display: true,
-              content: 'Budget ' + formatCurrency(budget),
+              content: 'Budget ' + formatCurrency(budget) + " (#{budget_hours}h)",
               position: 'start',
               yAdjust: 11,
               backgroundColor: 'transparent',

--- a/app/controllers/order_controlling_controller.rb
+++ b/app/controllers/order_controlling_controller.rb
@@ -12,6 +12,7 @@ class OrderControllingController < ApplicationController
     controlling = Order::Controlling.new(order)
     @efforts_per_week_cumulated = controlling.efforts_per_week_cumulated
     @offered_total = controlling.offered_total
+    @offered_hours = controlling.offered_hours
   end
 
   private

--- a/app/helpers/order_controlling_helper.rb
+++ b/app/helpers/order_controlling_helper.rb
@@ -26,7 +26,11 @@ module OrderControllingHelper
           data: @efforts_per_week_cumulated
             .keys
             .sort
-            .map { |week| @efforts_per_week_cumulated[week][set[:type]].to_i },
+            .map { |week| @efforts_per_week_cumulated[week][set[:type]][:amount] },
+          tooltipData: @efforts_per_week_cumulated
+            .keys
+            .sort
+            .map { |week| @efforts_per_week_cumulated[week][set[:type]][:hours] },
           backgroundColor: set[:color]
         }
       end.to_json.html_safe

--- a/app/views/order_controlling/show.html.haml
+++ b/app/views/order_controlling/show.html.haml
@@ -13,6 +13,7 @@
     #{controlling_chart_labels},
     #{controlling_chart_datasets},
     #{@offered_total.round(2)},
+    #{@offered_hours.round(2)},
     #{Settings.defaults.currency.to_json.html_safe},
     "KW #{Date.today.strftime('%W')} #{Date.today.strftime('%Y')}"
   );

--- a/test/domain/order/controlling_test.rb
+++ b/test/domain/order/controlling_test.rb
@@ -47,40 +47,40 @@ class Order
 
       expected = {}
       expected[Time.utc(2000, 1, 3)] = {
-        billable: 850.0,
-        unbillable: 300.0,
-        planned_definitive: 0.0,
-        planned_provisional: 0.0
+        billable: { amount: 850.0, hours: 8.0 },
+        unbillable: { amount: 300.0, hours: 3.0 },
+        planned_definitive: { amount: 0.0, hours: 0.0 },
+        planned_provisional: { amount: 0.0, hours: 0.0 }
       }
       expected[Time.utc(2000, 1, 3) + 1.week] = {
-        billable: 1300.0,
-        unbillable: 500.0,
-        planned_definitive: 0.0,
-        planned_provisional: 0.0
+        billable: { amount: 1300.0, hours: 13.0 },
+        unbillable: { amount: 500.0, hours: 5.0 },
+        planned_definitive: { amount: 0.0, hours: 0.0 },
+        planned_provisional: { amount: 0.0, hours: 0.0 }
       }
       expected[Time.utc(2000, 1, 3) + 2.weeks] = {
-        billable: 800.0,
-        unbillable: 0.0,
-        planned_definitive: 0.0,
-        planned_provisional: 0.0
+        billable: { amount: 800.0, hours: 8.0 },
+        unbillable: { amount: 0.0, hours: 0.0 },
+        planned_definitive: { amount: 0.0, hours: 0.0 },
+        planned_provisional: { amount: 0.0, hours: 0.0 }
       }
       expected[Time.utc(2000, 1, 3) + 3.weeks] = {
-        billable: 0.0,
-        unbillable: 0.0,
-        planned_definitive: 240 + 120,
-        planned_provisional: 320
+        billable: { amount: 0.0, hours: 0.0 },
+        unbillable: { amount: 0.0, hours: 0.0 },
+        planned_definitive: { amount: 360.0, hours: 3.2 },
+        planned_provisional: { amount: 320.0, hours: 3.2 }
       }
       expected[Time.utc(2000, 1, 3) + 4.weeks] = { # gap is filled with empty entry
-        billable: 0.0,
-        unbillable: 0.0,
-        planned_definitive: 0.0,
-        planned_provisional: 0.0
+        billable: { amount: 0.0, hours: 0.0 },
+        unbillable: { amount: 0.0, hours: 0.0 },
+        planned_definitive: { amount: 0.0, hours: 0.0 },
+        planned_provisional: { amount: 0.0, hours: 0.0 }
       }
       expected[Time.utc(2000, 1, 3) + 5.weeks] = {
-        billable: 0.0,
-        unbillable: 0.0,
-        planned_definitive: 480,
-        planned_provisional: 0.0
+        billable: { amount: 0.0, hours: 0.0 },
+        unbillable: { amount: 0.0, hours: 0.0 },
+        planned_definitive: { amount: 480.0, hours: 4.8 },
+        planned_provisional: { amount: 0.0, hours: 0.0 }
       }
 
       assert_equal expected, controlling.efforts_per_week
@@ -103,34 +103,34 @@ class Order
 
       expected = {}
       expected[Time.utc(2000, 1, 3)] = {
-        billable: 200.0,
-        unbillable: 100.0,
-        planned_definitive: 0.0,
-        planned_provisional: 0.0
+        billable: { amount: 200.0, hours: 2.0 },
+        unbillable: { amount: 100.0, hours: 1.0 },
+        planned_definitive: { amount: 0.0, hours: 0.0 },
+        planned_provisional: { amount: 0.0, hours: 0.0 }
       }
       expected[Time.utc(2000, 1, 3) + 1.week] = {
-        billable: 600.0,
-        unbillable: 400.0,
-        planned_definitive: 0.0,
-        planned_provisional: 0.0
+        billable: { amount: 600.0, hours: 6.0 },
+        unbillable: { amount: 400.0, hours: 4.0 },
+        planned_definitive: { amount: 0.0, hours: 0.0 },
+        planned_provisional: { amount: 0.0, hours: 0.0 }
       }
       expected[Time.utc(2000, 1, 3) + 2.weeks] = {
-        billable: 1100.0,
-        unbillable: 400.0,
-        planned_definitive: 0.0,
-        planned_provisional: 0.0
+        billable: { amount: 1100.0, hours: 11.0 },
+        unbillable: { amount: 400.0, hours: 4.0 },
+        planned_definitive: { amount: 0.0, hours: 0.0 },
+        planned_provisional: { amount: 0.0, hours: 0.0 }
       }
       expected[Time.utc(2000, 1, 3) + 3.weeks] = {
-        billable: 1100.0,
-        unbillable: 400.0,
-        planned_definitive: 80,
-        planned_provisional: 160
+        billable: { amount: 1100.0, hours: 11.0 },
+        unbillable: { amount: 400.0, hours: 4.0 },
+        planned_definitive: { amount: 80.0, hours: 0.8 },
+        planned_provisional: { amount: 160.0, hours: 1.6 }
       }
       expected[Time.utc(2000, 1, 3) + 4.weeks] = {
-        billable: 1100.0,
-        unbillable: 400.0,
-        planned_definitive: 320,
-        planned_provisional: 160
+        billable: { amount: 1100.0, hours: 11.0 },
+        unbillable: { amount: 400.0, hours: 4.0 },
+        planned_definitive: { amount: 320.0, hours: 3.2 },
+        planned_provisional: { amount: 160.0, hours: 1.6 }
       }
 
       assert_equal expected, controlling.efforts_per_week_cumulated

--- a/test/helpers/order_controlling_helper_test.rb
+++ b/test/helpers/order_controlling_helper_test.rb
@@ -13,22 +13,22 @@ class OrderControllingHelperTest < ActionView::TestCase
   def setup
     @efforts_per_week_cumulated = {}
     @efforts_per_week_cumulated[Time.utc(2000, 1, 3)] = {
-      billable: 10.0,
-      unbillable: 5.0,
-      planned_definitive: 0.0,
-      planned_provisional: 0.0
+      billable: { amount: 10.0, hours: 1.0 },
+      unbillable: { amount: 5.0, hours: 0.5 },
+      planned_definitive: { amount: 0.0, hours: 0.0 },
+      planned_provisional: { amount: 0.0, hours: 0.0 }
     }
     @efforts_per_week_cumulated[Time.utc(2000, 1, 3) + 1.week] = {
-      billable: 10.0,
-      unbillable: 5.0,
-      planned_definitive: 0.0,
-      planned_provisional: 0.0
+      billable: { amount: 10.0, hours: 1.0 },
+      unbillable: { amount: 5.0, hours: 0.5 },
+      planned_definitive: { amount: 0.0, hours: 0.0 },
+      planned_provisional: { amount: 0.0, hours: 0.0 }
     }
     @efforts_per_week_cumulated[Time.utc(2000, 1, 3) + 2.weeks] = {
-      billable: 20.0,
-      unbillable: 8.0,
-      planned_definitive: 2.0,
-      planned_provisional: 0.0
+      billable: { amount: 20.0, hours: 2.0 },
+      unbillable: { amount: 8.0, hours: 0.8 },
+      planned_definitive: { amount: 2.0, hours: 0.02 },
+      planned_provisional: { amount: 0.0, hours: 0.0 }
     }
   end
 
@@ -39,10 +39,10 @@ class OrderControllingHelperTest < ActionView::TestCase
 
   test '#controlling_chart_datasets' do
     assert_equal [
-      { label: 'Verrechenbar', data: [10, 10, 20], backgroundColor: '#69B978' },
-      { label: 'Nicht verrechenbar', data: [5, 5, 8], backgroundColor: '#f0e54e' },
-      { label: 'Definitiv geplant', data: [0, 0, 2], backgroundColor: '#4286e7' },
-      { label: 'Provisorisch geplant', data: [0, 0, 0], backgroundColor: '#9bcbd4' }
+      { label: 'Verrechenbar', data: [10.0, 10.0, 20.0], tooltipData: [1.0, 1.0, 2.0], backgroundColor: '#69B978' },
+      { label: 'Nicht verrechenbar', data: [5.0, 5.0, 8.0], tooltipData: [0.5, 0.5, 0.8], backgroundColor: '#f0e54e' },
+      { label: 'Definitiv geplant', data: [0.0, 0.0, 2.0], tooltipData: [0.0, 0.0, 0.02], backgroundColor: '#4286e7' },
+      { label: 'Provisorisch geplant', data: [0.0, 0.0, 0.0], tooltipData: [0.0, 0.0, 0.0], backgroundColor: '#9bcbd4' }
     ].to_json, controlling_chart_datasets
   end
 end


### PR DESCRIPTION
This applies a few formatting / UI changes to the Budget-Controlling tab. Explicitly, it formats the money amounts with an apostrophe (instead of comma) and adds the corresponding amount of hours everywhere.