### PR TITLE
only set responsible id if current user is actually in the list of order responsible (64304)

### DIFF
--- a/app/controllers/invoice_reports_controller.rb
+++ b/app/controllers/invoice_reports_controller.rb
@@ -40,7 +40,9 @@ class InvoiceReportsController < ApplicationController
   def set_default_params
     return if @report.filters_defined?
 
-    params.reverse_merge!(department_id: @user.department_id, responsible_id: @user.id, period_shortcut: '0q')
+    responsible_id = @user.id if Employee.joins(:managed_orders).exists?(id: @user.id)
+
+    params.reverse_merge!(department_id: @user.department_id, responsible_id: responsible_id, period_shortcut: '0q')
   end
 
   def authorize_class


### PR DESCRIPTION
This fixes a bug where for users which are not order responsibles anywhere the entries would be actually filtered according to where the user is responsible (no results) despite this filtering not being shown in the filter field, due to the user not being an option. This could lead to confusion.