### PR TITLE
fix loading logic in invoices controlling client filter when fetching invoices (64418)

### DIFF
--- a/app/domain/invoice/report.rb
+++ b/app/domain/invoice/report.rb
@@ -77,7 +77,7 @@ class Invoice
     # filter by customer
     def filter_by_parent(invoices)
       if params[:client_work_item_id].present?
-        invoices.joins(:order, :work_items).where('? = ANY (work_items.path_ids)', params[:client_work_item_id])
+        invoices.joins(order: :work_item).where('? = ANY (work_items.path_ids)', params[:client_work_item_id])
       else
         invoices
       end


### PR DESCRIPTION
join the invoice relation on the work_item id associated with the order of the invoice instead of doing a (erronous) flat join of invoice and work_item_id directly..

I don't know even know why the first one worked in the first place. @Kagemaru maybe you know why the first one worked? From my understanding, the Invoice relation doesn't have any work_items associated directly, why didn't the flat join throw an error?