### PR TITLE
fix bug where the order selection persisted when using browser back button (64416)

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -99,6 +99,12 @@ $(document).on('turbolinks:before-cache', ->
     this.selectize.destroy()
 )
 
+# if the page is loaded from the browser's bfcache (event.persisted == true), reload the page
+# to avoid some weird turbolinks bugs
+window.addEventListener 'pageshow', (event) ->
+  if event.persisted
+    location.reload()
+
 ################################################################
 # because of turbolinks.jquery, do bind ALL document events here
 


### PR DESCRIPTION
reload page on browser back if page is loaded from bfcache.

@Kagemaru This is maybe not very clean, but I don't know of an other possibility to circumvent the weird stuff turbolinks does (except upgrading to turbo ;) ). Does the implemented solution have any unwanted side-effects?